### PR TITLE
Fix PR template auto import

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Related Issue
+Closes #[issue number]
+
+## Summary
+<!-- Brief description of what this PR adds or fixes -->
+
+## Changes
+<!-- List the key changes made -->
+-
+
+## Test Procedures
+<!-- How did you test this? Be specific enough that a reviewer can reproduce. -->
+1.
+
+## Test Results
+<!-- What did you observe? Include any relevant data, screenshots, or serial output. -->
+
+## Checklist
+- [ ] Merged latest `dev` into this branch and resolved all conflicts
+- [ ] Tested on hardware (or documented why hardware testing was not applicable)
+- [ ] Reviewer assigned


### PR DESCRIPTION
## Related Issue
Closes #38 

## Summary
This PR moves the `feature_to_dev` PR template to a file called `.github/pull_request_template.md`. This ensures that this PR template is automatically included when creating a new PR. When creating a PR from `dev -> main`, we will have to manually include the appropriate template (located in `.github/PULL_REQUEST_TEMPLATE/dev_to_main.md`).

## Changes
- Copied `.github/PULL_REQUEST_TEMPLATE/feature_to_dev.md` to `.github/pull_request_template.md`. 

## Test Procedures
<!-- How did you test this? Be specific enough that a reviewer can reproduce. -->
No easy way to test that this auto-import works. I read github's doc and I'm 99% sure that this is the correct way to do it.

## Test Results
<!-- What did you observe? Include any relevant data, screenshots, or serial output. -->
N/A

## Checklist
- [x] Merged latest `dev` into this branch and resolved all conflicts
- [x] Tested on hardware (or documented why hardware testing was not applicable)
- [x] Reviewer assigned