### PR TITLE
Add ROS Spec information to README

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/feature_to_dev.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature_to_dev.md
@@ -17,5 +17,6 @@ Closes #[issue number]
 
 ## Checklist
 - [ ] Merged latest `dev` into this branch and resolved all conflicts
+- [ ] Documentation updated to reflect all changes in code and/or specifications
 - [ ] Tested on hardware (or documented why hardware testing was not applicable)
 - [ ] Reviewer assigned

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,5 +17,6 @@ Closes #[issue number]
 
 ## Checklist
 - [ ] Merged latest `dev` into this branch and resolved all conflicts
+- [ ] Documentation updated to reflect all changes in code and/or specifications
 - [ ] Tested on hardware (or documented why hardware testing was not applicable)
 - [ ] Reviewer assigned

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ source install/setup.bash
 
 The tasks for the upcoming demo are organized in a couple of key locations
 
-- [ros_specification](ROS_Specification.md) : This document outlines the communication specifications for all of the ROS nodes in the demo. All nodes should be developed to match these specifications. Each package also contains a README with the detailed specifications for the nodes required for those packages.
+- [ros_specification](ROS_Specification.md) : This document outlines the communication specifications for all of the ROS nodes in the demo. All nodes should be developed to match these specifications. Each package also contains a README with the detailed specifications for the nodes required for those packages. **Please ensure that any changes you make to the specification are reflected in these docs.**
 - [Github Issues](https://github.com/rammp-org/Demo-Software/issues): The individual tasks that need to be completed are all outlined here. Before starting on any work, please ensure that there is an issue open for it and that you are assigned to it.
 
 Please refer to **[CONTRIBUTING.MD](CONTRIBUTING.MD)** for detailed guidelines regarding:

--- a/README.md
+++ b/README.md
@@ -67,7 +67,12 @@ source install/setup.bash
 
 ## Contributing
 
-Please refer to **[CONTRIBUTING.MD](CONTRIBUTING.MD)** for detailed technical guidelines regarding:
+The tasks for the upcoming demo are organized in a couple of key locations
+
+- [ros_specification](ros_specification.md) : This document outlines the communication specifications for all of the ROS nodes in the demo. All nodes should be developed to match these specifications. Each package also contains a README with the detailed specifications for the nodes required for those packages.
+- [Github Issues](https://github.com/rammp-org/Demo-Software/issues): The individual tasks that need to be completed are all outlined here. Before starting on any work, please ensure that there is an issue open for it and that you are assigned to it.
+
+Please refer to **[CONTRIBUTING.MD](CONTRIBUTING.MD)** for detailed guidelines regarding:
 
 * Git branching strategy and naming conventions.
 * Code style requirements (PEP 8 for Python, ROS 2 C++ Style Guide).

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Foundational packages for the RAMMP prototype.
 * **`rammp_prototype_gui`**: Interface layer for communication with the Unreal Engine-based GUI.
 
 ### 2. Demo Modules (`demo_modules/`)
-Task-specific research modules provided by unveristy partners. These are self-contained "skills" (e.g., stabilization, navigation, manipulation) designed to interface with the core platform via standardized ROS 2 topics and actions.
+Task-specific research modules provided by university partners. These are self-contained "skills" (e.g., stabilization, navigation, manipulation) designed to interface with the core platform via standardized ROS 2 topics and actions.
 
 ### 3. Hardware Drivers (`hardware/`)
 Interfaces between the ROS 2 computational graph and physical components.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ source install/setup.bash
 
 The tasks for the upcoming demo are organized in a couple of key locations
 
-- [ros_specification](ros_specification.md) : This document outlines the communication specifications for all of the ROS nodes in the demo. All nodes should be developed to match these specifications. Each package also contains a README with the detailed specifications for the nodes required for those packages.
+- [ros_specification](ROS_Specification.md) : This document outlines the communication specifications for all of the ROS nodes in the demo. All nodes should be developed to match these specifications. Each package also contains a README with the detailed specifications for the nodes required for those packages.
 - [Github Issues](https://github.com/rammp-org/Demo-Software/issues): The individual tasks that need to be completed are all outlined here. Before starting on any work, please ensure that there is an issue open for it and that you are assigned to it.
 
 Please refer to **[CONTRIBUTING.MD](CONTRIBUTING.MD)** for detailed guidelines regarding:

--- a/ROS_Specification.md
+++ b/ROS_Specification.md
@@ -1,26 +1,32 @@
 
 # ROS Node Specifications
+This document defines the specification for all of the ROS nodes for the April 2026 RAMMP Prototype demo. The collection of specifications linked from this document should always reflect the full system architecture.
 
-[core/BehaviorTreeNode](./core/rammp_prototype_behavior/Behavior%20Tree%20Node.md)
-[core/GuiMonitorNode](./core/rammp_prototype_gui/GuiMonitorNode.md)
-[demo_modules/CupStabilizerNode](./demo_modules/atdev_coffee_stabilizer/Cup%20Stabilizer%20Node.md)
-[demo_modules/DoorOpenerNode](./demo_modules/cmu_door_opener/Door%20Open%20Node.md)
-[demo_modules/DrinkingNode](./demo_modules/cornell_feeding/Drinking%20Node.md)
-[demo_modules/NavigationNode](./demo_modules/neu_navigation/Navigation%20Node.md)
-[hardware/ArmControlNode](./hardware/arm_driver/Arm%20Control%20Node.md)
-[hardware/RammpPrototypeControlNode](./hardware/rammp_prototype_driver/MEBot%20Control%20Node.md)
-[hardware/XBoxControllerNode](./hardware/xbox_controller_driver/XBox%20Controller%20Node.md)
+## Node Specifications
+Each of these links define the specification for the various nodes in the ROS network..
+
+- [core/BehaviorTreeNode](./core/rammp_prototype_behavior/Behavior%20Tree%20Node.md)
+- [core/GuiMonitorNode](./core/rammp_prototype_gui/GuiMonitorNode.md)
+- [demo_modules/CupStabilizerNode](./demo_modules/atdev_coffee_stabilizer/Cup%20Stabilizer%20Node.md)
+- [demo_modules/DoorOpenerNode](./demo_modules/cmu_door_opener/Door%20Open%20Node.md)
+- [demo_modules/DrinkingNode](./demo_modules/cornell_feeding/Drinking%20Node.md)
+- [demo_modules/NavigationNode](./demo_modules/neu_navigation/Navigation%20Node.md)
+- [hardware/ArmControlNode](./hardware/arm_driver/Arm%20Control%20Node.md)
+- [hardware/RammpPrototypeControlNode](./hardware/rammp_prototype_driver/MEBot%20Control%20Node.md)
+- [hardware/XBoxControllerNode](./hardware/xbox_controller_driver/XBox%20Controller%20Node.md)
 
 
 ## ROS Node Diagram
 
+These diagrams outline the topics, actions, and services for communication between all of the nodes.
+
 ```mermaid
-%%{init: { 'theme': 'base', 
+%%{init: { 'theme': 'base',
 'flowchart': { 'nodeSpacing': 50, 'rankSpacing': 100 },'themeVariables': { 'primaryTextColor':'white', 'primaryBorderColor':'#ffffff'}}}%%
 graph RL
     subgraph legend[Diagram Legend]
-    
-        
+
+
         subgraph  arrows[Arrows]
         cm1[Communication Legend Node1]
         style cm1 fill:#000000
@@ -40,7 +46,7 @@ graph RL
         end
         subgraph Node[Node]
         Gui["Gui Nodes"]
-        style Gui fill:#0c7aba 
+        style Gui fill:#0c7aba
         style Gui width:230px,height:50px,text-anchor:middle
         Sensor["Sensor  Nodes"]
         style Sensor fill:#05723f
@@ -78,7 +84,7 @@ graph LR
     RSN["RealSense Node"]
     SCN["Static Camera Node"]
     NCN["Navigation Camera Node"]
-    
+
     BTN -->|/state| Gui
     Gui -->|/user_input| BTN
     Gui -->|/mebot/seat/manual_control| MBN
@@ -112,7 +118,7 @@ graph LR
     XCN -->|/estop| MBN
     XCN -->|/estop| BTN
     MBN -->|/luci/joystick/enable| LUCI
-    
+
     style Gui fill:#0c7aba
     style BTN fill:#8309ef
     style MBN fill:#ff6f61
@@ -135,6 +141,6 @@ graph LR
 
     %% ACTION connections (green)
     linkStyle 11,12,13,14,15 stroke:green,stroke-width:2px,color:green;
-    
+
 
 ```

--- a/ROS_Specification.md
+++ b/ROS_Specification.md
@@ -2,6 +2,8 @@
 # ROS Node Specifications
 This document defines the specification for all of the ROS nodes for the April 2026 RAMMP Prototype demo. The collection of specifications linked from this document should always reflect the full system architecture.
 
+**NOTE: As you are developing, please ensure that any changes in you are making in the ROS specification are reflected in the docs below.**
+
 ## Node Specifications
 Each of these links define the specification for the various nodes in the ROS network..
 


### PR DESCRIPTION
## Related Issue
Closes #37 

## Summary
Update the README to include information about the ROS specification.

## Changes
<!-- List the key changes made -->
- Update README to point to ROS specification and Github Issues.
- Add two bolded callouts that contributors should update ROS specifications if they need to change during development.
- Update PR template with a to-do list item to make sure that the appropriate docs are updated.
- Slight formatting changes in ROS spec for readability
- Fix typos in README


## Test Procedures
<!-- How did you test this? Be specific enough that a reviewer can reproduce. -->
I never have to test code if I only write docs 😈

## Test Results
<!-- What did you observe? Include any relevant data, screenshots, or serial output. -->
N/A

## Checklist
- [x] Merged latest `dev` into this branch and resolved all conflicts
- [x] Tested on hardware (or documented why hardware testing was not applicable)
- [x] Reviewer assigned
