### PR TITLE
Add GH workflows for static analysis and linting

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, dev]
   pull_request:
     branches: [main, dev]
+  workflow_dispatch:
 
 jobs:
   pre-commit:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,6 +7,8 @@ on:
     branches: [main, dev]
   workflow_dispatch:
 
+permissions:
+  contents: read
 jobs:
   pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,6 +15,6 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: "3.11"
 
       - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,19 @@
+name: Lint and Static Analysis
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Related Issue
Closes #7 

## Summary
Sets up a GH workflow to run the pre-commit hook analysis when a PR is opened to dev or main.

## Changes
- Add pre-commit workflow

## Test Procedures
<!-- How did you test this? Be specific enough that a reviewer can reproduce. -->
Testing by creating this PR

## Test Results
<!-- What did you observe? Include any relevant data, screenshots, or serial output. -->
We should see that the workflow runs successfully and that this PR passes the tests. 


## Checklist
- [x] Merged latest `dev` into this branch and resolved all conflicts
- [x] Documentation updated to reflect all changes in code and/or specifications
- [x] Tested on hardware (or documented why hardware testing was not applicable)
- [x] Reviewer assigned
