### PR TITLE
Setup Rosdep and ROS build workflow

### DIFF
--- a/.github/workflows/ros-build.yml
+++ b/.github/workflows/ros-build.yml
@@ -22,6 +22,11 @@ jobs:
         with:
           required-ros-distributions: humble
 
+      - name: Initialize rosdep
+        run: |
+          sudo rosdep init || true
+          rosdep update
+
       - name: Install dependencies
         run: rosdep install -i --from-path src --rosdistro humble -r -y
 

--- a/.github/workflows/ros-build.yml
+++ b/.github/workflows/ros-build.yml
@@ -1,0 +1,31 @@
+name: ROS 2 Build
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, ubuntu-22.04-arm]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: src/Demo-Software
+
+      - uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: humble
+
+      - name: Install dependencies
+        run: rosdep install -i --from-path src --rosdistro humble -r -y
+
+      - name: Build
+        run: |
+          source /opt/ros/humble/setup.bash
+          colcon build --symlink-install --event-handlers console_cohesion+

--- a/README.md
+++ b/README.md
@@ -61,12 +61,17 @@ git clone [https://github.com/rammp-org/Demo-Software.git](https://github.com/ra
 
 ### Building the Workspace
 
-Install dependencies using `rosdep` and build the packages. Using `--symlink-install` is recommended for development:
+If this is your first time using `rosdep`, initialize it:
+
+```bash
+sudo rosdep init
+rosdep update
+```
 
 ```bash
 cd ~/ros2_ws
-rosdep install -i --from-path src --rosdistro humble -y
-colcon build --symlink-install
+rosdep install -i --from-path src --rosdistro humble -r -y
+colcon build
 source install/setup.bash
 
 ```

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ rosdep update
 ```bash
 cd ~/ros2_ws
 rosdep install -i --from-path src --rosdistro humble -r -y
-colcon build
+colcon build --symlink-install
 source install/setup.bash
 
 ```


### PR DESCRIPTION
## Related Issue
Closes #30 
Closes #45 

## Summary
<!-- Brief description of what this PR adds or fixes -->
Updates README setup instructions to include instructions to install dependencies with `rosdep`. Additionally, add a GH workflow to automatically test builds of the codebase.

## Changes
<!-- List the key changes made -->
- Small changes to README getting started instructions to correctly setup rosdep
- Created GH workflow for testing builds on x64 and arm. We include arm to test jetson builds as well

## Test Procedures
<!-- How did you test this? Be specific enough that a reviewer can reproduce. -->
1. Testing the build process by creating this PR

## Test Results
<!-- What did you observe? Include any relevant data, screenshots, or serial output. -->
We should expect that the build is successful because the ROS codebase is empty currently :)

## Checklist
- [x] Merged latest `dev` into this branch and resolved all conflicts
- [x] Documentation updated to reflect all changes in code and/or specifications
- [x] Tested on hardware (or documented why hardware testing was not applicable)
- [x] Reviewer assigned
