### PR TITLE
Fix markdown pre-commit conflicts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
     rev: v4.5.0
     hooks:
       - id: trailing-whitespace
+        exclude: '(\.md$|\.markdown$)'
       - id: end-of-file-fixer
       - id: check-added-large-files
       - id: check-yaml


### PR DESCRIPTION
## Related Issue
Closes #47 

## Summary
Fixes the trailing whitespace conflict for MD files, preventing pre-commit checks from ever passing.

## Changes
<!-- List the key changes made -->
- Exclude markdown files from the `trailing-whitespace` hook.

## Test Procedures
<!-- How did you test this? Be specific enough that a reviewer can reproduce. -->
1. I ran the procedure that @ewang360 originally used to produce the bug and was able to reproduce.

## Test Results
<!-- What did you observe? Include any relevant data, screenshots, or serial output. -->
 After adding the exclusion, I was able to get the pre-commit checks to pass successfully. @ewang360 Please try this patch to see if this works for you.

## Checklist
- [x] Merged latest `dev` into this branch and resolved all conflicts
- [x] Documentation updated to reflect all changes in code and/or specifications
- [x] Tested on hardware (or documented why hardware testing was not applicable)
- [x] Reviewer assigned
