### PR TITLE
Fix Rosdep CI install

### DIFF
--- a/.github/workflows/ros-build.yml
+++ b/.github/workflows/ros-build.yml
@@ -20,10 +20,8 @@ jobs:
           path: src/Demo-Software
 
       - name: Install dependencies
-        run: |
-          apt-get update
-          rosdep update
-          rosdep install -i --from-path src --rosdistro humble -r -y
+        shell: bash
+        run: src/Demo-Software/setup.sh
 
       - name: Build
         shell: bash

--- a/.github/workflows/ros-build.yml
+++ b/.github/workflows/ros-build.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    container: ros:humble
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-22.04-arm]
@@ -18,18 +19,10 @@ jobs:
         with:
           path: src/Demo-Software
 
-      - uses: ros-tooling/setup-ros@v0.7
-        with:
-          required-ros-distributions: humble
-
-      - name: Initialize rosdep
-        run: |
-          sudo rosdep init || true
-          rosdep update
-
       - name: Install dependencies
         run: |
-          sudo apt-get update
+          apt-get update
+          rosdep update
           rosdep install -i --from-path src --rosdistro humble -r -y
 
       - name: Build

--- a/.github/workflows/ros-build.yml
+++ b/.github/workflows/ros-build.yml
@@ -28,7 +28,9 @@ jobs:
           rosdep update
 
       - name: Install dependencies
-        run: rosdep install -i --from-path src --rosdistro humble -r -y
+        run: |
+          sudo apt-get update
+          rosdep install -i --from-path src --rosdistro humble -r -y
 
       - name: Build
         run: |

--- a/.github/workflows/ros-build.yml
+++ b/.github/workflows/ros-build.yml
@@ -26,6 +26,7 @@ jobs:
           rosdep install -i --from-path src --rosdistro humble -r -y
 
       - name: Build
+        shell: bash
         run: |
           source /opt/ros/humble/setup.bash
           colcon build --symlink-install --event-handlers console_cohesion+

--- a/setup.sh
+++ b/setup.sh
@@ -12,6 +12,9 @@ fi
 ROSDEP_SOURCE="/etc/ros/rosdep/sources.list.d/50-rammp-custom.list"
 ROSDEP_YAML="file://${REPO_ROOT}/hardware/arm_driver/rosdep/python.yaml"
 
+echo "=== Updating apt ==="
+$SUDO apt-get update -q
+
 echo "=== Registering custom rosdep sources ==="
 echo "yaml ${ROSDEP_YAML}" | $SUDO tee "${ROSDEP_SOURCE}"
 

--- a/setup.sh
+++ b/setup.sh
@@ -2,17 +2,24 @@
 set -e
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ "$(id -u)" -eq 0 ]; then
+  SUDO=""
+else
+  SUDO="sudo"
+fi
+
 ROSDEP_SOURCE="/etc/ros/rosdep/sources.list.d/50-rammp-custom.list"
 ROSDEP_YAML="file://${REPO_ROOT}/hardware/arm_driver/rosdep/python.yaml"
 
 echo "=== Registering custom rosdep sources ==="
-echo "yaml ${ROSDEP_YAML}" | sudo tee "${ROSDEP_SOURCE}"
+echo "yaml ${ROSDEP_YAML}" | $SUDO tee "${ROSDEP_SOURCE}"
 
 echo "=== Updating rosdep ==="
 rosdep update
 
 echo "=== Installing pip ==="
-sudo apt-get install -y python3-pip
+$SUDO apt-get install -y python3-pip
 
 echo "=== Installing pip dependencies ==="
 pip3 install -r "${REPO_ROOT}/hardware/arm_driver/requirements.txt"


### PR DESCRIPTION
## Related Issue

Closes #77, fixes build issues for #74 

## Summary
<!-- Brief description of what this PR adds or fixes -->
Fixes the build failure caused by dependency resolution issues by switching the CI build to use a ROS humble docker container.

## Changes

<!-- List the key changes made -->
- Run the build jobs on a ros humble docker container
- Remove ROS humble installation from job
- Use setup.sh to install dependencies (which is the recommended flow in the repo)
- Update setup.sh to gracefully handle sudo not being installed (inside docker container)

## Test Procedures

<!-- How did you test this? Be specific enough that a reviewer can reproduce. -->
1. Built #74 with the ROS humble docker container
2. Tested the build locally after the change in setup.sh
3. Build on this PR

## Test Results

<!-- What did you observe? Include any relevant data, screenshots, or serial output. -->
1. Found that this fix allowed #74 to build successfully.
2. Found that setup.sh correctly installed dependencies for local builds
3. The build for this PR is expected to pass.

## Checklist

- [x] Merged latest `dev` into this branch and resolved all conflicts
- [x] Documentation updated to reflect all changes in code and/or specifications
- [x] Tested on hardware (or documented why hardware testing was not applicable)
- [x] Reviewer assigned
