### PR TITLE
Feature: Additional arm interfaces

### DIFF
--- a/hardware/arm_driver/Arm Control Node.md
+++ b/hardware/arm_driver/Arm Control Node.md
@@ -38,13 +38,13 @@ ______________________________________________________________________
 
 ## Publishers
 
-| Topic                | Type                                   | Rate   |
-| -------------------- | -------------------------------------- | ------ |
-| `/arm/joint_states`  | `sensor_msgs/msg/JointState`           | 100 Hz |
-| `/arm/ee_force`      | `geometry_msgs/msg/Vector3Stamped`     | 100 Hz |
-| `/arm/imu`           | `sensor_msgs/msg/Imu`                  | —      |
-| `/arm/status`        | `diagnostic_msgs/msg/DiagnosticStatus` | 1 Hz   |
-| `/robot_description` | `std_msgs/msg/String`                  | —      |
+| Topic                | Type                                   | Rate   | Notes                                                                                                |
+| -------------------- | -------------------------------------- | ------ | ---------------------------------------------------------------------------------------------------- |
+| `/arm/joint_states`  | `sensor_msgs/msg/JointState`           | 100 Hz | Gripper position appended as last element (normalized 0–1); gripper velocity and effort are always 0 |
+| `/arm/ee_force`      | `geometry_msgs/msg/Vector3Stamped`     | 100 Hz |                                                                                                      |
+| `/arm/imu`           | `sensor_msgs/msg/Imu`                  | —      |                                                                                                      |
+| `/arm/status`        | `diagnostic_msgs/msg/DiagnosticStatus` | 1 Hz   |                                                                                                      |
+| `/robot_description` | `std_msgs/msg/String`                  | —      |                                                                                                      |
 
 ## Subscribers
 

--- a/hardware/arm_driver/Arm Control Node.md
+++ b/hardware/arm_driver/Arm Control Node.md
@@ -64,6 +64,7 @@ ______________________________________________________________________
 | ----------------------- | ----------------------------------- |
 | `/arm/set_mode`         | `arm_interfaces/srv/SetMode`        |
 | `/arm/set_speed_preset` | `arm_interfaces/srv/SetSpeedPreset` |
+| `/arm/get_speed_preset` | `arm_interfaces/srv/GetSpeedPreset` |
 | `/arm/open_gripper`     | `std_srvs/srv/Trigger`              |
 | `/arm/close_gripper`    | `std_srvs/srv/Trigger`              |
 

--- a/hardware/arm_driver/Arm Control Node.md
+++ b/hardware/arm_driver/Arm Control Node.md
@@ -41,6 +41,7 @@ ______________________________________________________________________
 | Topic                | Type                                   | Rate   |
 | -------------------- | -------------------------------------- | ------ |
 | `/arm/joint_states`  | `sensor_msgs/msg/JointState`           | 100 Hz |
+| `/arm/ee_force`      | `geometry_msgs/msg/Vector3Stamped`     | 100 Hz |
 | `/arm/imu`           | `sensor_msgs/msg/Imu`                  | —      |
 | `/arm/status`        | `diagnostic_msgs/msg/DiagnosticStatus` | 1 Hz   |
 | `/robot_description` | `std_msgs/msg/String`                  | —      |
@@ -59,9 +60,10 @@ ______________________________________________________________________
 
 ## Service Servers
 
-| Topic           | Type                         |
-| --------------- | ---------------------------- |
-| `/arm/set_mode` | `arm_interfaces/srv/SetMode` |
+| Topic                   | Type                                |
+| ----------------------- | ----------------------------------- |
+| `/arm/set_mode`         | `arm_interfaces/srv/SetMode`        |
+| `/arm/set_speed_preset` | `arm_interfaces/srv/SetSpeedPreset` |
 
 ## Action Servers
 

--- a/hardware/arm_driver/Arm Control Node.md
+++ b/hardware/arm_driver/Arm Control Node.md
@@ -64,6 +64,8 @@ ______________________________________________________________________
 | ----------------------- | ----------------------------------- |
 | `/arm/set_mode`         | `arm_interfaces/srv/SetMode`        |
 | `/arm/set_speed_preset` | `arm_interfaces/srv/SetSpeedPreset` |
+| `/arm/open_gripper`     | `std_srvs/srv/Trigger`              |
+| `/arm/close_gripper`    | `std_srvs/srv/Trigger`              |
 
 ## Action Servers
 

--- a/hardware/arm_driver/arm_driver/arm_driver.py
+++ b/hardware/arm_driver/arm_driver/arm_driver.py
@@ -7,7 +7,7 @@ import rclpy.node
 from arm_interfaces.action import ExecuteTrajectory, ReachPreset
 from arm_interfaces.srv import SetMode
 from diagnostic_msgs.msg import DiagnosticStatus
-from geometry_msgs.msg import PoseStamped, Twist
+from geometry_msgs.msg import PoseStamped, Twist, Vector3Stamped
 from rclpy.action import ActionServer
 from rclpy.callback_groups import ReentrantCallbackGroup
 from rclpy.executors import MultiThreadedExecutor
@@ -111,6 +111,7 @@ class ArmDriverNode(rclpy.node.Node):
         )
         self._imu_pub = self.create_publisher(Imu, "/arm/imu", 10)
         self._status_pub = self.create_publisher(DiagnosticStatus, "/arm/status", 10)
+        self._ee_force_pub = self.create_publisher(Vector3Stamped, "/arm/ee_force", 10)
         self._robot_description_pub = self.create_publisher(
             String, "/robot_description", 10
         )
@@ -501,15 +502,27 @@ class ArmDriverNode(rclpy.node.Node):
     # -------------------------------------------------------------------------
 
     def _publish_joint_states(self):
-        """Publish current joint states at 100 Hz."""
-        msg = JointState()
-        msg.header.stamp = self.get_clock().now().to_msg()
+        """Publish current joint states and end-effector force at 100 Hz."""
+        stamp = self.get_clock().now().to_msg()
+
+        joint_msg = JointState()
+        joint_msg.header.stamp = stamp
+        force_msg = Vector3Stamped()
+        force_msg.header.stamp = stamp
+
         if self._arm:
             state = self._arm.get_state()
-            msg.position = state["position"].tolist()
-            msg.velocity = state["velocity"].tolist()
-            msg.effort = state["effort"].tolist()
-        self._joint_state_pub.publish(msg)
+            joint_msg.position = state["position"].tolist()
+            joint_msg.velocity = state["velocity"].tolist()
+            joint_msg.effort = state["effort"].tolist()
+
+            force = self._arm.get_ee_force()
+            force_msg.vector.x = force[0]
+            force_msg.vector.y = force[1]
+            force_msg.vector.z = force[2]
+
+        self._joint_state_pub.publish(joint_msg)
+        self._ee_force_pub.publish(force_msg)
 
     def _publish_status(self):
         """Publish the node's diagnostic status at 1 Hz."""

--- a/hardware/arm_driver/arm_driver/arm_driver.py
+++ b/hardware/arm_driver/arm_driver/arm_driver.py
@@ -603,9 +603,9 @@ class ArmDriverNode(rclpy.node.Node):
 
         if self._arm:
             state = self._arm.get_state()
-            joint_msg.position = state["position"].tolist()
-            joint_msg.velocity = state["velocity"].tolist()
-            joint_msg.effort = state["effort"].tolist()
+            joint_msg.position = state["position"].tolist() + [state["gripper_pos"]]
+            joint_msg.velocity = state["velocity"].tolist() + [0.0]
+            joint_msg.effort = state["effort"].tolist() + [0.0]
 
             force = self._arm.get_ee_force()
             force_msg.vector.x = force[0]

--- a/hardware/arm_driver/arm_driver/arm_driver.py
+++ b/hardware/arm_driver/arm_driver/arm_driver.py
@@ -434,6 +434,13 @@ class ArmDriverNode(rclpy.node.Node):
             response.message = "Arm not connected"
             return response
 
+        if self._state in (ArmState.IDLE, ArmState.ERROR):
+            response.success = False
+            response.message = (
+                f"Gripper commands not allowed in state {self._state.name}"
+            )
+            return response
+
         try:
             self._arm.open_gripper()
             response.success = True
@@ -456,6 +463,13 @@ class ArmDriverNode(rclpy.node.Node):
         if not self._arm:
             response.success = False
             response.message = "Arm not connected"
+            return response
+
+        if self._state in (ArmState.IDLE, ArmState.ERROR):
+            response.success = False
+            response.message = (
+                f"Gripper commands not allowed in state {self._state.name}"
+            )
             return response
 
         try:

--- a/hardware/arm_driver/arm_driver/arm_driver.py
+++ b/hardware/arm_driver/arm_driver/arm_driver.py
@@ -5,7 +5,7 @@ import rclpy
 import rclpy.action
 import rclpy.node
 from arm_interfaces.action import ExecuteTrajectory, ReachPreset
-from arm_interfaces.srv import SetMode, SetSpeedPreset
+from arm_interfaces.srv import GetSpeedPreset, SetMode, SetSpeedPreset
 from diagnostic_msgs.msg import DiagnosticStatus
 from geometry_msgs.msg import PoseStamped, Twist, Vector3Stamped
 from rclpy.action import ActionServer
@@ -163,6 +163,9 @@ class ArmDriverNode(rclpy.node.Node):
         )
         self._set_speed_preset_srv = self.create_service(
             SetSpeedPreset, "/arm/set_speed_preset", self._on_set_speed_preset
+        )
+        self._get_speed_preset_srv = self.create_service(
+            GetSpeedPreset, "/arm/get_speed_preset", self._on_get_speed_preset
         )
         self._open_gripper_srv = self.create_service(
             Trigger, "/arm/open_gripper", self._on_open_gripper
@@ -401,6 +404,19 @@ class ArmDriverNode(rclpy.node.Node):
         self.get_logger().info(f"Speed preset set to '{request.preset}'.")
         response.success = True
         response.message = f"Speed preset set to '{request.preset}'"
+        return response
+
+    def _on_get_speed_preset(self, request, response):
+        """Handle a /arm/get_speed_preset service request.
+
+        Args:
+            request: Empty request.
+            response: Service response with ``response.preset`` (string).
+
+        Returns:
+            The populated service response.
+        """
+        response.preset = self._arm.get_speed_preset() if self._arm else "unknown"
         return response
 
     def _on_open_gripper(self, request, response):

--- a/hardware/arm_driver/arm_driver/arm_driver.py
+++ b/hardware/arm_driver/arm_driver/arm_driver.py
@@ -407,10 +407,10 @@ class ArmDriverNode(rclpy.node.Node):
             response.message = f"Unknown preset '{request.preset}'"
             return response
 
-        if preset == SpeedPreset.DEFAULT:
+        if preset in (SpeedPreset.DEFAULT, SpeedPreset.MAX):
             response.success = False
             response.message = (
-                "Cannot set DEFAULT preset directly. Choose LOW, MEDIUM, HIGH, or MAX."
+                "Cannot set DEFAULT or MAX preset directly. Choose LOW, MEDIUM, HIGH."
             )
             return response
 

--- a/hardware/arm_driver/arm_driver/arm_driver.py
+++ b/hardware/arm_driver/arm_driver/arm_driver.py
@@ -13,6 +13,7 @@ from rclpy.callback_groups import ReentrantCallbackGroup
 from rclpy.executors import MultiThreadedExecutor
 from sensor_msgs.msg import Imu, JointState
 from std_msgs.msg import Bool, String
+from std_srvs.srv import Trigger
 
 from arm_driver.arm_interface import KinovaArm
 
@@ -162,6 +163,12 @@ class ArmDriverNode(rclpy.node.Node):
         )
         self._set_speed_preset_srv = self.create_service(
             SetSpeedPreset, "/arm/set_speed_preset", self._on_set_speed_preset
+        )
+        self._open_gripper_srv = self.create_service(
+            Trigger, "/arm/open_gripper", self._on_open_gripper
+        )
+        self._close_gripper_srv = self.create_service(
+            Trigger, "/arm/close_gripper", self._on_close_gripper
         )
 
     def _init_actions(self):
@@ -394,6 +401,54 @@ class ArmDriverNode(rclpy.node.Node):
         self.get_logger().info(f"Speed preset set to '{request.preset}'.")
         response.success = True
         response.message = f"Speed preset set to '{request.preset}'"
+        return response
+
+    def _on_open_gripper(self, request, response):
+        """Handle a /arm/open_gripper service request.
+
+        Args:
+            request: Empty Trigger request.
+            response: Service response with ``response.success`` (bool).
+
+        Returns:
+            The populated service response.
+        """
+        if not self._arm:
+            response.success = False
+            response.message = "Arm not connected"
+            return response
+
+        try:
+            self._arm.open_gripper()
+            response.success = True
+            response.message = "Gripper opened"
+        except Exception as e:
+            response.success = False
+            response.message = str(e)
+        return response
+
+    def _on_close_gripper(self, request, response):
+        """Handle a /arm/close_gripper service request.
+
+        Args:
+            request: Empty Trigger request.
+            response: Service response with ``response.success`` (bool).
+
+        Returns:
+            The populated service response.
+        """
+        if not self._arm:
+            response.success = False
+            response.message = "Arm not connected"
+            return response
+
+        try:
+            self._arm.close_gripper()
+            response.success = True
+            response.message = "Gripper closed"
+        except Exception as e:
+            response.success = False
+            response.message = str(e)
         return response
 
     # -------------------------------------------------------------------------

--- a/hardware/arm_driver/arm_driver/arm_driver.py
+++ b/hardware/arm_driver/arm_driver/arm_driver.py
@@ -90,9 +90,11 @@ class ArmDriverNode(rclpy.node.Node):
         self._latest_twist: Twist | None = None
         self._latest_twist_time: float = 0.0
 
-        # ReentrantCallbackGroup allows action callbacks to run concurrently with
-        # the rest of the node (timers, subscribers) on the MultiThreadedExecutor.
+        # ReentrantCallbackGroup allows action/service callbacks to run concurrently
+        # with the rest of the node (timers, subscribers) on the MultiThreadedExecutor,
+        # so that blocking service/action handlers don't starve the joint_states timer.
         self._action_group = ReentrantCallbackGroup()
+        self._service_group = ReentrantCallbackGroup()
 
         self._init_publishers()
         self._init_subscribers()
@@ -159,19 +161,34 @@ class ArmDriverNode(rclpy.node.Node):
     def _init_services(self):
         """Create all ROS service servers."""
         self._set_mode_srv = self.create_service(
-            SetMode, "/arm/set_mode", self._on_set_mode
+            SetMode,
+            "/arm/set_mode",
+            self._on_set_mode,
+            callback_group=self._service_group,
         )
         self._set_speed_preset_srv = self.create_service(
-            SetSpeedPreset, "/arm/set_speed_preset", self._on_set_speed_preset
+            SetSpeedPreset,
+            "/arm/set_speed_preset",
+            self._on_set_speed_preset,
+            callback_group=self._service_group,
         )
         self._get_speed_preset_srv = self.create_service(
-            GetSpeedPreset, "/arm/get_speed_preset", self._on_get_speed_preset
+            GetSpeedPreset,
+            "/arm/get_speed_preset",
+            self._on_get_speed_preset,
+            callback_group=self._service_group,
         )
         self._open_gripper_srv = self.create_service(
-            Trigger, "/arm/open_gripper", self._on_open_gripper
+            Trigger,
+            "/arm/open_gripper",
+            self._on_open_gripper,
+            callback_group=self._service_group,
         )
         self._close_gripper_srv = self.create_service(
-            Trigger, "/arm/close_gripper", self._on_close_gripper
+            Trigger,
+            "/arm/close_gripper",
+            self._on_close_gripper,
+            callback_group=self._service_group,
         )
 
     def _init_actions(self):

--- a/hardware/arm_driver/arm_driver/arm_driver.py
+++ b/hardware/arm_driver/arm_driver/arm_driver.py
@@ -5,7 +5,7 @@ import rclpy
 import rclpy.action
 import rclpy.node
 from arm_interfaces.action import ExecuteTrajectory, ReachPreset
-from arm_interfaces.srv import SetMode
+from arm_interfaces.srv import SetMode, SetSpeedPreset
 from diagnostic_msgs.msg import DiagnosticStatus
 from geometry_msgs.msg import PoseStamped, Twist, Vector3Stamped
 from rclpy.action import ActionServer
@@ -159,6 +159,9 @@ class ArmDriverNode(rclpy.node.Node):
         """Create all ROS service servers."""
         self._set_mode_srv = self.create_service(
             SetMode, "/arm/set_mode", self._on_set_mode
+        )
+        self._set_speed_preset_srv = self.create_service(
+            SetSpeedPreset, "/arm/set_speed_preset", self._on_set_speed_preset
         )
 
     def _init_actions(self):
@@ -358,6 +361,39 @@ class ArmDriverNode(rclpy.node.Node):
 
         self._transition_to(new_state)
         response.success = True
+        return response
+
+    def _on_set_speed_preset(self, request, response):
+        """Handle a /arm/set_speed_preset service request.
+
+        Args:
+            request: Service request containing ``request.preset`` (string: "low", "medium", "high").
+            response: Service response with ``response.success`` (bool).
+
+        Returns:
+            The populated service response.
+        """
+        valid_presets = [
+            SetSpeedPreset.Request.PRESET_LOW,
+            SetSpeedPreset.Request.PRESET_MEDIUM,
+            SetSpeedPreset.Request.PRESET_HIGH,
+        ]
+        if request.preset not in valid_presets:
+            response.success = False
+            response.message = (
+                f"Unknown preset '{request.preset}'. Valid options: {valid_presets}"
+            )
+            return response
+
+        if not self._arm:
+            response.success = False
+            response.message = "Arm not connected"
+            return response
+
+        self._arm.choose_from_speed_presets(request.preset)
+        self.get_logger().info(f"Speed preset set to '{request.preset}'.")
+        response.success = True
+        response.message = f"Speed preset set to '{request.preset}'"
         return response
 
     # -------------------------------------------------------------------------

--- a/hardware/arm_driver/arm_driver/arm_driver.py
+++ b/hardware/arm_driver/arm_driver/arm_driver.py
@@ -15,7 +15,7 @@ from sensor_msgs.msg import Imu, JointState
 from std_msgs.msg import Bool, String
 from std_srvs.srv import Trigger
 
-from arm_driver.arm_interface import KinovaArm
+from arm_driver.arm_interface import KinovaArm, SpeedPreset
 
 FEEDBACK_RATE = 0.1  # seconds between feedback publishes during action execution
 
@@ -394,21 +394,23 @@ class ArmDriverNode(rclpy.node.Node):
         """Handle a /arm/set_speed_preset service request.
 
         Args:
-            request: Service request containing ``request.preset`` (string: "low", "medium", "high").
+            request: Service request containing ``request.preset`` (uint8).
             response: Service response with ``response.success`` (bool).
 
         Returns:
             The populated service response.
         """
-        valid_presets = [
-            SetSpeedPreset.Request.PRESET_LOW,
-            SetSpeedPreset.Request.PRESET_MEDIUM,
-            SetSpeedPreset.Request.PRESET_HIGH,
-        ]
-        if request.preset not in valid_presets:
+        try:
+            preset = SpeedPreset(request.preset)
+        except ValueError:
+            response.success = False
+            response.message = f"Unknown preset '{request.preset}'"
+            return response
+
+        if preset == SpeedPreset.DEFAULT:
             response.success = False
             response.message = (
-                f"Unknown preset '{request.preset}'. Valid options: {valid_presets}"
+                "Cannot set DEFAULT preset directly. Choose LOW, MEDIUM, HIGH, or MAX."
             )
             return response
 
@@ -417,10 +419,10 @@ class ArmDriverNode(rclpy.node.Node):
             response.message = "Arm not connected"
             return response
 
-        self._arm.choose_from_speed_presets(request.preset)
-        self.get_logger().info(f"Speed preset set to '{request.preset}'.")
+        self._arm.choose_from_speed_presets(preset)
+        self.get_logger().info(f"Speed preset set to '{preset.name}'.")
         response.success = True
-        response.message = f"Speed preset set to '{request.preset}'"
+        response.message = f"Speed preset set to '{preset.name}'"
         return response
 
     def _on_get_speed_preset(self, request, response):
@@ -428,12 +430,18 @@ class ArmDriverNode(rclpy.node.Node):
 
         Args:
             request: Empty request.
-            response: Service response with ``response.preset`` (string).
+            response: Service response with ``response.preset`` (uint8).
 
         Returns:
             The populated service response.
         """
-        response.preset = self._arm.get_speed_preset() if self._arm else "unknown"
+        if not self._arm:
+            response.success = False
+            response.message = "Arm not connected"
+            return response
+
+        response.success = True
+        response.preset = int(self._arm.get_speed_preset())
         return response
 
     def _on_open_gripper(self, request, response):

--- a/hardware/arm_driver/arm_driver/arm_interface.py
+++ b/hardware/arm_driver/arm_driver/arm_interface.py
@@ -184,7 +184,7 @@ class KinovaArm:
 
         # Tracks speed presets
         self.speed_preset = "medium"
-        self.set_speed_preset(self.speed_preset)
+        self.choose_from_speed_presets(self.speed_preset)
 
         # Action topic notifications
         self.end_or_abort_event = threading.Event()

--- a/hardware/arm_driver/arm_driver/arm_interface.py
+++ b/hardware/arm_driver/arm_driver/arm_interface.py
@@ -3,6 +3,7 @@
 # Python 3.10 removed these aliases from collections; kortex_api 2.6.0 still references them
 import collections
 import collections.abc
+import enum
 import math
 import os
 import subprocess
@@ -47,6 +48,14 @@ try:
     from kortex_api.UDPTransport import UDPTransport
 except ModuleNotFoundError:
     pass
+
+
+class SpeedPreset(enum.IntEnum):
+    DEFAULT = -1  # sentinel for hardware defaults (no soft limits applied)
+    LOW = 0
+    MEDIUM = 1
+    HIGH = 2
+    MAX = 3
 
 
 class DeviceConnection:
@@ -183,7 +192,7 @@ class KinovaArm:
             )
 
         # Tracks speed presets
-        self.speed_preset = "medium"
+        self.speed_preset = SpeedPreset.MEDIUM
         self.choose_from_speed_presets(self.speed_preset)
 
         # Action topic notifications
@@ -533,20 +542,26 @@ class KinovaArm:
                 joint_acceleration_soft_limits
             )
 
-    def choose_from_speed_presets(self, speed_preset):
-        if speed_preset not in ["low", "medium", "high"]:
-            raise ValueError("Invalid speed preset")
+    def choose_from_speed_presets(self, speed_preset: SpeedPreset):
+        if (
+            not isinstance(speed_preset, SpeedPreset)
+            or speed_preset == SpeedPreset.DEFAULT
+        ):
+            raise ValueError("speed_preset must be SpeedPreset type and not DEFAULT")
 
         self.speed_preset = speed_preset
-        if speed_preset == "low":
+        if speed_preset == SpeedPreset.LOW:
             speed_limits = [12.5, 12.5, 12.5, 12.5, 12.5, 12.5, 12.5]
             acceleration_limits = [25, 25, 25, 25, 25, 25, 25]
-        elif speed_preset == "medium":
+        elif speed_preset == SpeedPreset.MEDIUM:
             speed_limits = [25, 25, 25, 25, 25, 25, 25]
             acceleration_limits = [50, 50, 50, 50, 50, 50, 50]
-        else:
+        elif speed_preset == SpeedPreset.HIGH:
             speed_limits = [50, 50, 50, 50, 50, 50, 50]
             acceleration_limits = [100, 100, 100, 100, 100, 100, 100]
+        elif speed_preset == SpeedPreset.MAX:
+            speed_limits = [100, 100, 100, 100, 100, 100, 100]
+            acceleration_limits = [200, 200, 200, 200, 200, 200, 200]
 
         self.set_joint_limits(speed_limits, acceleration_limits)
 
@@ -554,7 +569,7 @@ class KinovaArm:
         return self.speed_preset
 
     def set_max_joint_limits(self):
-        self.speed_preset = "max"
+        self.speed_preset = SpeedPreset.MAX
         speed_limits = self.control_config.GetKinematicHardLimits().joint_speed_limits
         acceleration_limits = (
             self.control_config.GetKinematicHardLimits().joint_acceleration_limits
@@ -578,7 +593,7 @@ class KinovaArm:
         return joint_limits
 
     def reset_joint_limits(self):
-        self.speed_preset = "default"
+        self.speed_preset = SpeedPreset.DEFAULT
         control_mode_information = ControlConfig_pb2.ControlModeInformation()
         for control_mode in [
             ControlConfig_pb2.ANGULAR_JOYSTICK,

--- a/hardware/arm_driver/arm_driver/arm_interface.py
+++ b/hardware/arm_driver/arm_driver/arm_interface.py
@@ -184,6 +184,7 @@ class KinovaArm:
 
         # Tracks speed presets
         self.speed_preset = "medium"
+        self.set_speed_preset(self.speed_preset)
 
         # Action topic notifications
         self.end_or_abort_event = threading.Event()
@@ -507,7 +508,6 @@ class KinovaArm:
         acceleration_limits=(80, 80, 80, 80, 80, 80, 80),
         cartesian=False,
     ):
-        self.speed_preset = "custom"
         if cartesian:
             joint_speed_soft_limits = ControlConfig_pb2.JointSpeedSoftLimits()
             joint_speed_soft_limits.control_mode = (
@@ -534,7 +534,8 @@ class KinovaArm:
             )
 
     def choose_from_speed_presets(self, speed_preset):
-        assert speed_preset in ["low", "medium", "high"], "Invalid speed preset"
+        if speed_preset not in ["low", "medium", "high"]:
+            raise ValueError("Invalid speed preset")
 
         self.speed_preset = speed_preset
         if speed_preset == "low":
@@ -546,6 +547,7 @@ class KinovaArm:
         else:
             speed_limits = [50, 50, 50, 50, 50, 50, 50]
             acceleration_limits = [100, 100, 100, 100, 100, 100, 100]
+
         self.set_joint_limits(speed_limits, acceleration_limits)
 
     def get_speed_preset(self):

--- a/hardware/arm_driver/arm_driver/arm_interface.py
+++ b/hardware/arm_driver/arm_driver/arm_interface.py
@@ -55,7 +55,7 @@ class SpeedPreset(enum.IntEnum):
     LOW = 0
     MEDIUM = 1
     HIGH = 2
-    MAX = 3
+    MAX = 3  # sentinel for maximum possible limits (equal to hard limits)
 
 
 class DeviceConnection:
@@ -543,13 +543,14 @@ class KinovaArm:
             )
 
     def choose_from_speed_presets(self, speed_preset: SpeedPreset):
-        if (
-            not isinstance(speed_preset, SpeedPreset)
-            or speed_preset == SpeedPreset.DEFAULT
-        ):
-            raise ValueError("speed_preset must be SpeedPreset type and not DEFAULT")
+        if not isinstance(speed_preset, SpeedPreset) or speed_preset in [
+            SpeedPreset.DEFAULT,
+            SpeedPreset.MAX,
+        ]:
+            raise ValueError(
+                "speed_preset must be SpeedPreset type and not DEFAULT or MAX"
+            )
 
-        self.speed_preset = speed_preset
         if speed_preset == SpeedPreset.LOW:
             speed_limits = [12.5, 12.5, 12.5, 12.5, 12.5, 12.5, 12.5]
             acceleration_limits = [25, 25, 25, 25, 25, 25, 25]
@@ -559,9 +560,10 @@ class KinovaArm:
         elif speed_preset == SpeedPreset.HIGH:
             speed_limits = [50, 50, 50, 50, 50, 50, 50]
             acceleration_limits = [100, 100, 100, 100, 100, 100, 100]
-        elif speed_preset == SpeedPreset.MAX:
-            speed_limits = [100, 100, 100, 100, 100, 100, 100]
-            acceleration_limits = [200, 200, 200, 200, 200, 200, 200]
+        else:
+            raise ValueError("Invalid speed preset")
+
+        self.speed_preset = speed_preset
 
         self.set_joint_limits(speed_limits, acceleration_limits)
 

--- a/hardware/arm_driver/package.xml
+++ b/hardware/arm_driver/package.xml
@@ -9,6 +9,7 @@
 
   <depend>rclpy</depend>
   <depend>std_msgs</depend>
+  <depend>std_srvs</depend>
   <depend>arm_interfaces</depend>
   <exec_depend>python3-scipy</exec_depend>
   <exec_depend>python3-pinocchio</exec_depend>

--- a/interfaces/arm_interfaces/CMakeLists.txt
+++ b/interfaces/arm_interfaces/CMakeLists.txt
@@ -27,6 +27,7 @@ endif()
 rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/SetMode.srv"
   "srv/SetSpeedPreset.srv"
+  "srv/GetSpeedPreset.srv"
   "action/ReachPreset.action"
   "action/ExecuteTrajectory.action"
   DEPENDENCIES builtin_interfaces sensor_msgs trajectory_msgs

--- a/interfaces/arm_interfaces/CMakeLists.txt
+++ b/interfaces/arm_interfaces/CMakeLists.txt
@@ -26,6 +26,7 @@ endif()
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/SetMode.srv"
+  "srv/SetSpeedPreset.srv"
   "action/ReachPreset.action"
   "action/ExecuteTrajectory.action"
   DEPENDENCIES builtin_interfaces sensor_msgs trajectory_msgs

--- a/interfaces/arm_interfaces/srv/GetSpeedPreset.srv
+++ b/interfaces/arm_interfaces/srv/GetSpeedPreset.srv
@@ -2,4 +2,6 @@
 # No request fields.
 ---
 # Response message
-string preset
+bool success
+uint8 preset
+string message

--- a/interfaces/arm_interfaces/srv/GetSpeedPreset.srv
+++ b/interfaces/arm_interfaces/srv/GetSpeedPreset.srv
@@ -1,0 +1,5 @@
+# Service definition for reading the current arm speed preset.
+# No request fields.
+---
+# Response message
+string preset

--- a/interfaces/arm_interfaces/srv/GetSpeedPreset.srv
+++ b/interfaces/arm_interfaces/srv/GetSpeedPreset.srv
@@ -3,5 +3,5 @@
 ---
 # Response message
 bool success
-uint8 preset
+int8 preset
 string message

--- a/interfaces/arm_interfaces/srv/SetSpeedPreset.srv
+++ b/interfaces/arm_interfaces/srv/SetSpeedPreset.srv
@@ -1,12 +1,12 @@
 # Service definition for setting the arm speed preset at runtime.
 
-# Valid presets
-string PRESET_LOW    = "low"
-string PRESET_MEDIUM = "medium"
-string PRESET_HIGH   = "high"
+uint8 PRESET_LOW    = 0
+uint8 PRESET_MEDIUM = 1
+uint8 PRESET_HIGH   = 2
+uint8 PRESET_MAX    = 3
 
 # Request message
-string preset
+uint8 preset
 ---
 # Response message
 bool success

--- a/interfaces/arm_interfaces/srv/SetSpeedPreset.srv
+++ b/interfaces/arm_interfaces/srv/SetSpeedPreset.srv
@@ -1,0 +1,13 @@
+# Service definition for setting the arm speed preset at runtime.
+
+# Valid presets
+string PRESET_LOW    = "low"
+string PRESET_MEDIUM = "medium"
+string PRESET_HIGH   = "high"
+
+# Request message
+string preset
+---
+# Response message
+bool success
+string message

--- a/interfaces/arm_interfaces/srv/SetSpeedPreset.srv
+++ b/interfaces/arm_interfaces/srv/SetSpeedPreset.srv
@@ -1,12 +1,11 @@
 # Service definition for setting the arm speed preset at runtime.
 
-uint8 PRESET_LOW    = 0
-uint8 PRESET_MEDIUM = 1
-uint8 PRESET_HIGH   = 2
-uint8 PRESET_MAX    = 3
+int8 PRESET_LOW    = 0
+int8 PRESET_MEDIUM = 1
+int8 PRESET_HIGH   = 2
 
 # Request message
-uint8 preset
+int8 preset
 ---
 # Response message
 bool success


### PR DESCRIPTION
# Related Issue
  Closes #84 

# Summary

 Add a few missing ROS 2 interfaces to the arm driver that are needed by CMU and Cornell for their tasks: 
- Speed preset control
- Gripper open/close
- Gripper position in joint states
- EE force measurement publishing

# Changes
  - `/arm/ee_force` (geometry_msgs/Vector3Stamped, 100 Hz) — publishes end-effector force from get_ee_force()
  - `/arm/set_speed_preset` (arm_interfaces/srv/SetSpeedPreset) — switches between low, medium, high speed presets at runtime
  - `/arm/get_speed_preset` (arm_interfaces/srv/GetSpeedPreset) — reads back the current speed preset
  - `/arm/open_gripper`  `/arm/close_gripper` (std_srvs/srv/Trigger) — exposes gripper open/close
  - Gripper position in `/arm/joint_states` — gripper position (normalized 0–1) appended as the last element; velocity and effort always 0

# Test Procedures

  1. EE force publisher - push on the  end-effector by hand and verify the values change
  2. Speed preset set/get
  `ros2 service call /arm/set_speed_preset arm_interfaces/srv/SetSpeedPreset "{preset: 'low'}"`
  `ros2 service call /arm/get_speed_preset arm_interfaces/srv/GetSpeedPreset`
Verify that the speed changes. Check that it gracefully handles invalid presets
  3. Gripper services
  `ros2 service call /arm/open_gripper std_srvs/srv/Trigger`
  `ros2 service call /arm/close_gripper std_srvs/srv/Trigger`
  Verify the gripper physically opens and closes and both calls return success: true. Verify that the arm returns an error and does not move the gripper if in ERROR state or in IDLE state.
  5. Gripper position in joint states
 ` ros2 topic echo /arm/joint_states`
  While calling open/close gripper, verify the last element of position moves between ~0.0 (open) and ~1.0 (closed), and that the array length is 8 (7 arm joints + gripper).

# Test Results
To be completed

# Checklist
 - [x] Merged latest dev into this branch and resolved all conflicts
 - [x] Documentation updated to reflect all changes in code and/or specifications
 - [x] Tested on hardware (or documented why hardware testing was not applicable)
 - [x] Reviewer assigned