### PR TITLE
Update setup.sh to run rosdep across all packages in repo

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -29,7 +29,7 @@ pip3 install -r "${REPO_ROOT}/hardware/arm_driver/requirements.txt"
 
 echo "=== Installing ROS dependencies ==="
 rosdep install \
-  --from-paths "${REPO_ROOT}/core" "${REPO_ROOT}/hardware/arm_driver" "${REPO_ROOT}/interfaces" \
+  --from-paths "${REPO_ROOT}" \
   --ignore-src -r -y \
   --skip-keys "python3-kortex-api python3-pinocchio python3-scipy"
 


### PR DESCRIPTION
## Related Issue

Closes #89

## Summary

Fixes CI builds by updating `rosdep` to run across all packages in the repo

## Changes

<!-- List the key changes made -->

- Change `setup.sh` to have `rosdep` to check deps for all packages

## Test Procedures

<!-- How did you test this? Be specific enough that a reviewer can reproduce. -->

1. Build for this PR should succeed if this is fixed. This would suggest that all of the dependencies are being properly installed.

## Test Results

Build was indeed successful, this fixes the broken CI build on the `dev` branch woooo

<!-- What did you observe? Include any relevant data, screenshots, or serial output. -->

## Checklist

- [x] Merged latest `dev` into this branch and resolved all conflicts
- [x] Documentation updated to reflect all changes in code and/or specifications
- [x] Tested on hardware (or documented why hardware testing was not applicable)
- [x] Reviewer assigned
