### PR TITLE
Add fixes for twist inputs

### DIFF
--- a/hardware/arm_driver/arm_driver/arm_driver.py
+++ b/hardware/arm_driver/arm_driver/arm_driver.py
@@ -1,6 +1,7 @@
 import enum
 import time
 
+import numpy as np
 import rclpy
 import rclpy.action
 import rclpy.node
@@ -87,9 +88,6 @@ class ArmDriverNode(rclpy.node.Node):
         self._state = ArmState.IDLE
         self._error_reason: str = ""
         self._arm: KinovaArm | None = None
-        self._latest_twist: Twist | None = None
-        self._latest_twist_time: float = 0.0
-
         # ReentrantCallbackGroup allows action/service callbacks to run concurrently
         # with the rest of the node (timers, subscribers) on the MultiThreadedExecutor,
         # so that blocking service/action handlers don't starve the joint_states timer.
@@ -217,11 +215,9 @@ class ArmDriverNode(rclpy.node.Node):
         ]
 
     def _init_timers(self):
-        """Create periodic timers for state publishing and twist streaming."""
+        """Create periodic timers for state publishing."""
         self.create_timer(0.01, self._publish_joint_states)  # 100 Hz
         self.create_timer(1.0, self._publish_status)  # 1 Hz
-        self._twist_timer = self.create_timer(0.04, self._stream_twist)  # 25 Hz
-        self._twist_timer.cancel()  # only active while in a TWIST state
 
     def _init_arm(self):
         """Connect to the Kinova arm. Transitions to ERROR on failure."""
@@ -240,9 +236,6 @@ class ArmDriverNode(rclpy.node.Node):
     def _transition_to(self, new_state: ArmState):
         """Transition the node to a new state, logging the change.
 
-        If leaving a TWIST state, clears the cached twist so the streaming timer
-        stops sending commands.
-
         Args:
             new_state: The state to transition to.
         """
@@ -250,18 +243,6 @@ class ArmDriverNode(rclpy.node.Node):
 
         if self._arm:
             self._arm.stop()
-
-        old_mode = COMMAND_MODE.get(self._state)
-        new_mode = COMMAND_MODE.get(new_state)
-
-        if old_mode != CommandMode.TWIST and new_mode == CommandMode.TWIST:
-            self._twist_timer.reset()
-
-        elif new_mode != CommandMode.TWIST:
-            self._twist_timer.cancel()
-            # Clear the twist cache when leaving a TWIST state so the arm stops if we re-enter a TWIST state without receiving a new command
-            self._latest_twist = None
-            self._latest_twist_time = 0.0
 
         self._state = new_state
 
@@ -285,16 +266,19 @@ class ArmDriverNode(rclpy.node.Node):
         handler(msg)
 
     def _handle_twist(self, msg: Twist):
-        """Cache the latest Cartesian twist command for the streaming timer.
+        """Send a Cartesian twist command directly to the arm.
 
-        The actual ``send_twist`` call happens in :meth:`_stream_twist` at 25 Hz
-        so that the arm receives a steady command stream regardless of publisher rate.
+        Bypasses the streaming timer — commands are forwarded to the hardware
+        immediately at whatever rate the publisher sends them.
 
         Args:
             msg: Desired end-effector linear and angular velocity.
         """
-        self._latest_twist = msg
-        self._latest_twist_time = time.monotonic()
+        if self._arm:
+            self._arm.send_twist(
+                [msg.linear.x, msg.linear.y, msg.linear.z],
+                [msg.angular.x, msg.angular.y, msg.angular.z],
+            )
 
     def _handle_joint_position(self, msg: JointState):
         """Command the arm to a target joint position (HIGH_LEVEL).
@@ -313,32 +297,6 @@ class ArmDriverNode(rclpy.node.Node):
         p = msg.pose.position
         q = msg.pose.orientation
         self._arm.move_cartesian([p.x, p.y, p.z], [q.x, q.y, q.z, q.w], blocking=False)
-
-    def _stream_twist(self):
-        """Send the latest cached twist command to the arm at 25 Hz.
-
-        Only active while in a TWIST state (timer is cancelled otherwise). Acts as a
-        watchdog: if no fresh twist has been received within 200 ms, sends a
-        zero-velocity command and clears the cache so the arm comes to a stop.
-        """
-        if not self._arm:
-            return
-
-        now = time.monotonic()
-        if now - self._latest_twist_time > 0.2:
-            # Watchdog expired — stop the arm and clear the cache
-            self._arm.send_twist([0.0, 0.0, 0.0], [0.0, 0.0, 0.0])
-            self._latest_twist = None
-            return
-
-        if self._latest_twist is None:
-            return
-
-        msg = self._latest_twist
-        self._arm.send_twist(
-            [msg.linear.x, msg.linear.y, msg.linear.z],
-            [msg.angular.x, msg.angular.y, msg.angular.z],
-        )
 
     # -------------------------------------------------------------------------
     # Subscribers
@@ -689,9 +647,9 @@ class ArmDriverNode(rclpy.node.Node):
             vel_msg.twist.linear.x = ee_velocity[0]
             vel_msg.twist.linear.y = ee_velocity[1]
             vel_msg.twist.linear.z = ee_velocity[2]
-            vel_msg.twist.angular.x = ee_velocity[3]
-            vel_msg.twist.angular.y = ee_velocity[4]
-            vel_msg.twist.angular.z = ee_velocity[5]
+            vel_msg.twist.angular.x = np.deg2rad(ee_velocity[3])
+            vel_msg.twist.angular.y = np.deg2rad(ee_velocity[4])
+            vel_msg.twist.angular.z = np.deg2rad(ee_velocity[5])
 
         self._joint_state_pub.publish(joint_msg)
         self._ee_vel_pub.publish(vel_msg)

--- a/hardware/arm_driver/arm_driver/arm_interface.py
+++ b/hardware/arm_driver/arm_driver/arm_interface.py
@@ -353,15 +353,18 @@ class KinovaArm:
             base_feedback.base.tool_twist_linear_y,
             base_feedback.base.tool_twist_linear_z,
         )
-        # Provide velocity as 3 angular velocity components in tool frame
-        tool_rot_vel = np.array(
+        # Kortex reports angular velocity in the base frame (deg/s).
+        # Rotate into tool frame to match SendTwistCommand's
+        # CARTESIAN_REFERENCE_FRAME_MIXED convention (angular in tool frame).
+        angular_vel_base_degs = np.array(
             [
                 base_feedback.base.tool_twist_angular_x,
                 base_feedback.base.tool_twist_angular_y,
                 base_feedback.base.tool_twist_angular_z,
             ]
         )
-        ee_vel[3:] = tool_rot_vel
+        R_tool_in_base = R.from_euler("xyz", np.deg2rad(tool_rot))
+        ee_vel[3:] = R_tool_in_base.inv().apply(angular_vel_base_degs)
 
         ee_force[:3] = (
             base_feedback.base.tool_external_wrench_force_x,
@@ -572,6 +575,13 @@ class KinovaArm:
 
         self.set_joint_limits(speed_limits, acceleration_limits)
 
+        # Also apply to CARTESIAN_JOYSTICK, which governs SendTwistCommand
+        # (ANGULAR_TRAJECTORY limits set above do not affect Twist velocity control)
+        cartesian_joystick_limits = ControlConfig_pb2.JointSpeedSoftLimits()
+        cartesian_joystick_limits.control_mode = ControlConfig_pb2.CARTESIAN_JOYSTICK
+        cartesian_joystick_limits.joint_speed_soft_limits.extend(speed_limits)
+        self.control_config.SetJointSpeedSoftLimits(cartesian_joystick_limits)
+
     def get_speed_preset(self):
         return self.speed_preset
 
@@ -582,6 +592,11 @@ class KinovaArm:
             self.control_config.GetKinematicHardLimits().joint_acceleration_limits
         )
         self.set_joint_limits(speed_limits, acceleration_limits)
+
+        cartesian_joystick_limits = ControlConfig_pb2.JointSpeedSoftLimits()
+        cartesian_joystick_limits.control_mode = ControlConfig_pb2.CARTESIAN_JOYSTICK
+        cartesian_joystick_limits.joint_speed_soft_limits.extend(speed_limits)
+        self.control_config.SetJointSpeedSoftLimits(cartesian_joystick_limits)
 
     def get_joint_limits(self):
         joint_limits = []


### PR DESCRIPTION
## Related Issue

Closes #127 

## Summary
Corrects bugs causing jittery motions when commanding the arm with Twist commands.

## Changes
- Previously, we had a timer set up to publish Twist commands to the arm at a fixed frequency. We've now moved to directly publishing the Twist command to the arm once the twist message is received on the topic - this reduces latency in controlling the arm and has eliminated the jittery motions.
- Cleaned up infrastructure to support fixed frequency twist publishing
- Correct units (degrees -> radians) and the coordinate frame (base_link -> ee) for the end effector rotational velocities. Linear velocities are still in base frame

## Test Procedures and Results

<!-- How did you test this? Be specific enough that a reviewer can reproduce. -->

1. First, we reproduced the error with the AT-dev coffee cup stabilizer and the gamepad node. We saw that the motions were jittery and did not clearly correlate with the commands that were being sent.
2. We applied the patches and executed the same code to send twist commands. After the patches, we were able to execute a smooth sine wave velocity profile (cup stabilization) and correctly control the arm with the gamepad.

3. To confirm the coordinate frame, we commanded the end effector to rotate. In an incorrect frame, the velocity vector direction should change as the arm rotates - in the correct frame, the vector direction should stay the same. When tested, that is exactly the behavior we see!

## Checklist

- [x] Merged latest `dev` into this branch and resolved all conflicts
- [x] Documentation updated to reflect all changes in code and/or specifications
- [x] Tested on hardware (or documented why hardware testing was not applicable)
- [x] Reviewer assigned
