### PR TITLE
Fix/138 arms comms timeout

### DIFF
--- a/hardware/arm_driver/arm_driver/arm_driver.py
+++ b/hardware/arm_driver/arm_driver/arm_driver.py
@@ -1,3 +1,4 @@
+import concurrent.futures
 import enum
 import time
 
@@ -621,7 +622,14 @@ class ArmDriverNode(rclpy.node.Node):
         pos_msg.header.stamp = stamp
 
         if self._arm:
-            state = self._arm.get_state()
+            try:
+                state = self._arm.get_state()
+            except (TimeoutError, concurrent.futures.TimeoutError):
+                self.get_logger().warn(
+                    "RefreshFeedback timed out — skipping publish cycle",
+                    throttle_duration_sec=1.0,
+                )
+                return
             joint_msg.name = [
                 f"joint_{i + 1}" for i in range(self._arm.actuator_count)
             ] + ["robotiq_85_left_knuckle_joint"]

--- a/hardware/arm_driver/arm_driver/arm_driver.py
+++ b/hardware/arm_driver/arm_driver/arm_driver.py
@@ -243,7 +243,13 @@ class ArmDriverNode(rclpy.node.Node):
         self.get_logger().info(f"State: {self._state.name} -> {new_state.name}")
 
         if self._arm:
-            self._arm.stop()
+            try:
+                self._arm.stop()
+            except Exception:
+                self.get_logger().warn(
+                    "stop() failed during state transition — continuing",
+                    throttle_duration_sec=1.0,
+                )
 
         self._state = new_state
 
@@ -276,10 +282,16 @@ class ArmDriverNode(rclpy.node.Node):
             msg: Desired end-effector linear and angular velocity.
         """
         if self._arm:
-            self._arm.send_twist(
-                [msg.linear.x, msg.linear.y, msg.linear.z],
-                [msg.angular.x, msg.angular.y, msg.angular.z],
-            )
+            try:
+                self._arm.send_twist(
+                    [msg.linear.x, msg.linear.y, msg.linear.z],
+                    [msg.angular.x, msg.angular.y, msg.angular.z],
+                )
+            except Exception:
+                self.get_logger().warn(
+                    "send_twist timed out — skipping command",
+                    throttle_duration_sec=1.0,
+                )
 
     def _handle_joint_position(self, msg: JointState):
         """Command the arm to a target joint position (HIGH_LEVEL).
@@ -287,7 +299,15 @@ class ArmDriverNode(rclpy.node.Node):
         Args:
             msg: Desired joint positions in ``msg.position`` (radians).
         """
-        self._arm.move_angular(list(msg.position), blocking=False)
+        if not self._arm:
+            return
+        try:
+            self._arm.move_angular(list(msg.position), blocking=False)
+        except Exception:
+            self.get_logger().warn(
+                "move_angular timed out — skipping command",
+                throttle_duration_sec=1.0,
+            )
 
     def _handle_cartesian_pose(self, msg: PoseStamped):
         """Command the arm to a target end-effector Cartesian pose (HIGH_LEVEL).
@@ -295,9 +315,19 @@ class ArmDriverNode(rclpy.node.Node):
         Args:
             msg: Desired end-effector pose in Cartesian space.
         """
+        if not self._arm:
+            return
         p = msg.pose.position
         q = msg.pose.orientation
-        self._arm.move_cartesian([p.x, p.y, p.z], [q.x, q.y, q.z, q.w], blocking=False)
+        try:
+            self._arm.move_cartesian(
+                [p.x, p.y, p.z], [q.x, q.y, q.z, q.w], blocking=False
+            )
+        except Exception:
+            self.get_logger().warn(
+                "move_cartesian timed out — skipping command",
+                throttle_duration_sec=1.0,
+            )
 
     # -------------------------------------------------------------------------
     # Subscribers
@@ -380,7 +410,12 @@ class ArmDriverNode(rclpy.node.Node):
             response.message = "Arm not connected"
             return response
 
-        self._arm.choose_from_speed_presets(preset)
+        try:
+            self._arm.choose_from_speed_presets(preset)
+        except Exception as e:
+            response.success = False
+            response.message = f"Failed to set speed preset: {e}"
+            return response
         self.get_logger().info(f"Speed preset set to '{preset.name}'.")
         response.success = True
         response.message = f"Speed preset set to '{preset.name}'"
@@ -508,7 +543,15 @@ class ArmDriverNode(rclpy.node.Node):
                     result.success = False
                     result.message = self._error_reason
                     return result
-                state = self._arm.get_state()
+                try:
+                    state = self._arm.get_state()
+                except (TimeoutError, concurrent.futures.TimeoutError):
+                    self.get_logger().warn(
+                        "get_state() timed out in feedback loop — skipping cycle",
+                        throttle_duration_sec=1.0,
+                    )
+                    time.sleep(FEEDBACK_RATE)
+                    continue
                 feedback.joint_states.header.stamp = self.get_clock().now().to_msg()
                 feedback.joint_states.position = state["position"].tolist()
                 feedback.joint_states.velocity = state["velocity"].tolist()
@@ -614,7 +657,15 @@ class ArmDriverNode(rclpy.node.Node):
                     result.success = False
                     result.message = self._error_reason
                     return result
-                state = self._arm.get_state()
+                try:
+                    state = self._arm.get_state()
+                except (TimeoutError, concurrent.futures.TimeoutError):
+                    self.get_logger().warn(
+                        "get_state() timed out in feedback loop — skipping cycle",
+                        throttle_duration_sec=1.0,
+                    )
+                    time.sleep(FEEDBACK_RATE)
+                    continue
                 feedback.joint_states.header.stamp = self.get_clock().now().to_msg()
                 feedback.joint_states.position = state["position"].tolist()
                 feedback.joint_states.velocity = state["velocity"].tolist()

--- a/hardware/arm_driver/arm_driver/arm_driver.py
+++ b/hardware/arm_driver/arm_driver/arm_driver.py
@@ -489,8 +489,20 @@ class ArmDriverNode(rclpy.node.Node):
         try:
             arm_fn(blocking=False)
             feedback = ReachPreset.Feedback()
+            deadline = time.monotonic() + KinovaArm.ACTION_TIMEOUT_DURATION
             while not self._arm.ready():
                 if self._state == ArmState.ERROR:
+                    goal_handle.abort()
+                    result = ReachPreset.Result()
+                    result.success = False
+                    result.message = self._error_reason
+                    return result
+                if time.monotonic() >= deadline:
+                    self.get_logger().error(
+                        "Reference action timed out waiting for arm ready signal"
+                    )
+                    self._error_reason = "Reference action timed out"
+                    self._transition_to(ArmState.ERROR)
                     goal_handle.abort()
                     result = ReachPreset.Result()
                     result.success = False
@@ -583,7 +595,19 @@ class ArmDriverNode(rclpy.node.Node):
         try:
             self._arm.move_angular_trajectory(waypoints, blocking=False)
             feedback = ExecuteTrajectory.Feedback()
+            deadline = time.monotonic() + KinovaArm.ACTION_TIMEOUT_DURATION
             while not self._arm.ready():
+                if time.monotonic() >= deadline:
+                    self.get_logger().error(
+                        "Trajectory action timed out waiting for arm ready signal"
+                    )
+                    self._error_reason = "Trajectory action timed out"
+                    self._transition_to(ArmState.ERROR)
+                    goal_handle.abort()
+                    result = ExecuteTrajectory.Result()
+                    result.success = False
+                    result.message = self._error_reason
+                    return result
                 state = self._arm.get_state()
                 feedback.joint_states.header.stamp = self.get_clock().now().to_msg()
                 feedback.joint_states.position = state["position"].tolist()

--- a/hardware/arm_driver/arm_driver/arm_driver.py
+++ b/hardware/arm_driver/arm_driver/arm_driver.py
@@ -289,9 +289,16 @@ class ArmDriverNode(rclpy.node.Node):
                 )
             except Exception:
                 self.get_logger().warn(
-                    "send_twist timed out — skipping command",
+                    "send_twist failed — stopping arm to prevent runaway motion",
                     throttle_duration_sec=1.0,
                 )
+                try:
+                    self._arm.stop()
+                except Exception:
+                    self.get_logger().warn(
+                        "stop() also failed after send_twist error",
+                        throttle_duration_sec=1.0,
+                    )
 
     def _handle_joint_position(self, msg: JointState):
         """Command the arm to a target joint position (HIGH_LEVEL).
@@ -545,9 +552,9 @@ class ArmDriverNode(rclpy.node.Node):
                     return result
                 try:
                     state = self._arm.get_state()
-                except (TimeoutError, concurrent.futures.TimeoutError):
+                except Exception:
                     self.get_logger().warn(
-                        "get_state() timed out in feedback loop — skipping cycle",
+                        "get_state() failed in feedback loop — skipping cycle",
                         throttle_duration_sec=1.0,
                     )
                     time.sleep(FEEDBACK_RATE)
@@ -659,9 +666,9 @@ class ArmDriverNode(rclpy.node.Node):
                     return result
                 try:
                     state = self._arm.get_state()
-                except (TimeoutError, concurrent.futures.TimeoutError):
+                except Exception:
                     self.get_logger().warn(
-                        "get_state() timed out in feedback loop — skipping cycle",
+                        "get_state() failed in feedback loop — skipping cycle",
                         throttle_duration_sec=1.0,
                     )
                     time.sleep(FEEDBACK_RATE)

--- a/hardware/arm_driver/arm_driver/arm_driver.py
+++ b/hardware/arm_driver/arm_driver/arm_driver.py
@@ -597,6 +597,12 @@ class ArmDriverNode(rclpy.node.Node):
             feedback = ExecuteTrajectory.Feedback()
             deadline = time.monotonic() + KinovaArm.ACTION_TIMEOUT_DURATION
             while not self._arm.ready():
+                if self._state == ArmState.ERROR:
+                    goal_handle.abort()
+                    result = ExecuteTrajectory.Result()
+                    result.success = False
+                    result.message = self._error_reason
+                    return result
                 if time.monotonic() >= deadline:
                     self.get_logger().error(
                         "Trajectory action timed out waiting for arm ready signal"

--- a/hardware/arm_driver/arm_driver/arm_driver.py
+++ b/hardware/arm_driver/arm_driver/arm_driver.py
@@ -245,9 +245,9 @@ class ArmDriverNode(rclpy.node.Node):
         if self._arm:
             try:
                 self._arm.stop()
-            except Exception:
+            except Exception as e:
                 self.get_logger().warn(
-                    "stop() failed during state transition — continuing",
+                    f"stop() failed during state transition — continuing: {e}",
                     throttle_duration_sec=1.0,
                 )
 
@@ -287,16 +287,16 @@ class ArmDriverNode(rclpy.node.Node):
                     [msg.linear.x, msg.linear.y, msg.linear.z],
                     [msg.angular.x, msg.angular.y, msg.angular.z],
                 )
-            except Exception:
+            except Exception as e:
                 self.get_logger().warn(
-                    "send_twist failed — stopping arm to prevent runaway motion",
+                    f"send_twist failed ({e!r}) — stopping arm to prevent runaway motion",
                     throttle_duration_sec=1.0,
                 )
                 try:
                     self._arm.stop()
-                except Exception:
+                except Exception as stop_exc:
                     self.get_logger().warn(
-                        "stop() also failed after send_twist error",
+                        f"stop() also failed after send_twist error ({stop_exc!r})",
                         throttle_duration_sec=1.0,
                     )
 
@@ -310,9 +310,9 @@ class ArmDriverNode(rclpy.node.Node):
             return
         try:
             self._arm.move_angular(list(msg.position), blocking=False)
-        except Exception:
+        except Exception as e:
             self.get_logger().warn(
-                "move_angular timed out — skipping command",
+                f"move_angular failed ({e!r}) — skipping command",
                 throttle_duration_sec=1.0,
             )
 
@@ -330,9 +330,9 @@ class ArmDriverNode(rclpy.node.Node):
             self._arm.move_cartesian(
                 [p.x, p.y, p.z], [q.x, q.y, q.z, q.w], blocking=False
             )
-        except Exception:
+        except Exception as e:
             self.get_logger().warn(
-                "move_cartesian timed out — skipping command",
+                f"move_cartesian failed ({e!r}) — skipping command",
                 throttle_duration_sec=1.0,
             )
 
@@ -552,9 +552,9 @@ class ArmDriverNode(rclpy.node.Node):
                     return result
                 try:
                     state = self._arm.get_state()
-                except Exception:
+                except Exception as e:
                     self.get_logger().warn(
-                        "get_state() failed in feedback loop — skipping cycle",
+                        f"get_state() failed in feedback loop ({e!r}) — skipping cycle",
                         throttle_duration_sec=1.0,
                     )
                     time.sleep(FEEDBACK_RATE)
@@ -666,9 +666,9 @@ class ArmDriverNode(rclpy.node.Node):
                     return result
                 try:
                     state = self._arm.get_state()
-                except Exception:
+                except Exception as e:
                     self.get_logger().warn(
-                        "get_state() failed in feedback loop — skipping cycle",
+                        f"get_state() failed in feedback loop ({e!r}) — skipping cycle",
                         throttle_duration_sec=1.0,
                     )
                     time.sleep(FEEDBACK_RATE)

--- a/hardware/arm_driver/arm_driver/arm_interface.py
+++ b/hardware/arm_driver/arm_driver/arm_interface.py
@@ -157,6 +157,8 @@ class KinovaArm:
         ]
         self.send_options = RouterClientSendOptions()
         self.send_options.timeout_ms = 50
+        self.control_send_options = RouterClientSendOptions()
+        self.control_send_options.timeout_ms = 200
 
         # clear faults
         self.clear_faults()
@@ -230,7 +232,7 @@ class KinovaArm:
         return self.end_or_abort_event.is_set()
 
     def wait_ready(self):
-        self.end_or_abort_event.wait(KinovaArm.ACTION_TIMEOUT_DURATION)
+        return self.end_or_abort_event.wait(KinovaArm.ACTION_TIMEOUT_DURATION)
 
     def set_arm_servoing_mode(self, mode):
         if mode == "high":
@@ -291,7 +293,7 @@ class KinovaArm:
         command.twist.angular_x = math.degrees(angular_xyz[0])
         command.twist.angular_y = math.degrees(angular_xyz[1])
         command.twist.angular_z = math.degrees(angular_xyz[2])
-        self.base.SendTwistCommand(command)
+        self.base.SendTwistCommand(command, options=self.control_send_options)
 
     def set_intermediate_zero_config(self):
         intermediate_zero_config = [0.0, 0.0, -3.12, 0.0, 0.0, 0.0, 0.0]
@@ -508,7 +510,9 @@ class KinovaArm:
             gripper_request.mode = Base_pb2.GRIPPER_POSITION
             start_time = time.perf_counter()
             while time.perf_counter() - start_time < timeout:
-                gripper_measure = self.base.GetMeasuredGripperMovement(gripper_request)
+                gripper_measure = self.base.GetMeasuredGripperMovement(
+                    gripper_request, options=self.control_send_options
+                )
                 if abs(value - gripper_measure.finger[0].value) < 0.01:
                     break
                 time.sleep(0.01)
@@ -667,12 +671,17 @@ class KinovaArm:
     # def apply_emergency_stop(self):
     #     self.base.ApplyEmergencyStop()
 
-    def clear_faults(self):
+    def clear_faults(self, timeout=5.0):
         if self.base.GetArmState().active_state == Base_pb2.ARMSTATE_IN_FAULT:
             self.base.ClearFaults()
+            deadline = time.perf_counter() + timeout
             while (
                 self.base.GetArmState().active_state != Base_pb2.ARMSTATE_SERVOING_READY
             ):
+                if time.perf_counter() >= deadline:
+                    raise TimeoutError(
+                        f"clear_faults: arm did not reach SERVOING_READY within {timeout}s"
+                    )
                 time.sleep(0.1)
 
 

--- a/hardware/arm_driver/arm_driver/arm_interface.py
+++ b/hardware/arm_driver/arm_driver/arm_interface.py
@@ -246,9 +246,10 @@ class KinovaArm:
 
     def _execute_reference_action(self, action_name, blocking=True):
         # Retrieve reference action
+        opts = self.control_send_options
         action_type = Base_pb2.RequestedActionType()
         action_type.action_type = Base_pb2.REACH_JOINT_ANGLES
-        action_list = self.base.ReadAllActions(action_type)
+        action_list = self.base.ReadAllActions(action_type, options=opts)
         action_handle = None
         for action in action_list.action_list:
             if action.name == action_name:
@@ -258,7 +259,7 @@ class KinovaArm:
 
         # Execute action
         self.end_or_abort_event.clear()
-        self.base.ExecuteActionFromReference(action_handle)
+        self.base.ExecuteActionFromReference(action_handle, options=opts)
         if blocking:
             self.end_or_abort_event.wait(KinovaArm.ACTION_TIMEOUT_DURATION)
 
@@ -391,10 +392,11 @@ class KinovaArm:
         }
 
     def move_angular_trajectory(self, trajectory_joint_angles, blocking=True):
+        opts = self.control_send_options
         assert len(trajectory_joint_angles) > 0, "Invalid trajectory"
-        assert (
-            len(trajectory_joint_angles[0]) == self.actuator_count
-        ), "Invalid number of joint angles"
+        assert len(trajectory_joint_angles[0]) == self.actuator_count, (
+            "Invalid number of joint angles"
+        )
 
         jointPoses = [
             [math.degrees(angle) for angle in jointPose]
@@ -413,12 +415,12 @@ class KinovaArm:
             waypoint.angular_waypoint.duration = 0.5
             index = index + 1
 
-        result = self.base.ValidateWaypointList(waypoints)
+        result = self.base.ValidateWaypointList(waypoints, options=opts)
         if len(result.trajectory_error_report.trajectory_error_elements) == 0:
             print("Reaching angular pose trajectory...")
 
             self.end_or_abort_event.clear()
-            self.base.ExecuteWaypointTrajectory(waypoints)
+            self.base.ExecuteWaypointTrajectory(waypoints, options=opts)
 
             if blocking:
                 print("Waiting for trajectory to finish ...")
@@ -434,9 +436,9 @@ class KinovaArm:
             print(result.trajectory_error_report)
 
     def move_angular(self, joint_angles, blocking=True):
-        assert (
-            len(joint_angles) == self.actuator_count
-        ), "Invalid number of joint angles"
+        assert len(joint_angles) == self.actuator_count, (
+            "Invalid number of joint angles"
+        )
 
         # Create action
         action = Base_pb2.Action()
@@ -445,9 +447,8 @@ class KinovaArm:
             joint_angle.joint_identifier = i
             joint_angle.value = math.degrees(joint_angles[i])
         self.end_or_abort_event.clear()
-        self.base.ExecuteAction(action)
+        self.base.ExecuteAction(action, options=self.control_send_options)
         if blocking:
-            print("Waiting for angular movement to finish ...")
             self.end_or_abort_event.wait(KinovaArm.ACTION_TIMEOUT_DURATION)
             # read states and check if the arm actually reached the desired position
             current_state = self.get_state()
@@ -459,13 +460,11 @@ class KinovaArm:
                 error = np.where(error < -180, error + 360, error)
 
             if np.any(np.abs(error) > 5):  # 5 degrees
-                print("Arm did not reach desired position")
                 self.stop()
-                print("Arm stopped")
-                self.disconnect()
-                print("Arm disconnected")
-            else:
-                print("Angular movement completed")
+                raise RuntimeError(
+                    f"Arm did not reach desired angular position; "
+                    f"max error {np.max(np.abs(error)):.1f} deg exceeds 5 deg threshold"
+                )
 
     def move_cartesian(self, xyz, xyz_quat, blocking=True):
         theta_xyz = R.from_quat(xyz_quat).as_euler("xyz")
@@ -480,29 +479,28 @@ class KinovaArm:
         cartesian_pose.theta_y = math.degrees(theta_xyz[1])
         cartesian_pose.theta_z = math.degrees(theta_xyz[2])
         self.end_or_abort_event.clear()
-        self.base.ExecuteAction(action)
+        self.base.ExecuteAction(action, options=self.control_send_options)
         if blocking:
-            print("Waiting for cartesian movement to finish ...")
             self.end_or_abort_event.wait(KinovaArm.ACTION_TIMEOUT_DURATION)
             # read states and check if the arm actually reached the desired position
             current_state = self.get_state()
             x = current_state["ee_pos"]
             if not np.allclose(x[:3], xyz, atol=0.01):  # 1 cm
-                print("Arm did not reach desired position")
                 self.stop()
-                print("Arm stopped")
-                self.disconnect()
-                print("Arm disconnected")
-            else:
-                print("Cartesian movement completed")
+                raise RuntimeError(
+                    f"Arm did not reach desired Cartesian position; "
+                    f"actual={x[:3].tolist()}, target={xyz}"
+                )
 
     def _gripper_position_command(self, value, blocking=True, timeout=1.0):
+        b = self.base
+        opts = self.control_send_options
         # Send gripper command
         gripper_command = Base_pb2.GripperCommand()
         gripper_command.mode = Base_pb2.GRIPPER_POSITION
         finger = gripper_command.gripper.finger.add()
         finger.value = value
-        self.base.SendGripperCommand(gripper_command)
+        b.SendGripperCommand(gripper_command, options=opts)
 
         if blocking:
             # Wait for reported position to match value
@@ -510,8 +508,8 @@ class KinovaArm:
             gripper_request.mode = Base_pb2.GRIPPER_POSITION
             start_time = time.perf_counter()
             while time.perf_counter() - start_time < timeout:
-                gripper_measure = self.base.GetMeasuredGripperMovement(
-                    gripper_request, options=self.control_send_options
+                gripper_measure = b.GetMeasuredGripperMovement(
+                    gripper_request, options=opts
                 )
                 if abs(value - gripper_measure.finger[0].value) < 0.01:
                     break
@@ -529,18 +527,20 @@ class KinovaArm:
         acceleration_limits=(80, 80, 80, 80, 80, 80, 80),
         cartesian=False,
     ):
+        cc = self.control_config
+        opts = self.control_send_options
         if cartesian:
             joint_speed_soft_limits = ControlConfig_pb2.JointSpeedSoftLimits()
             joint_speed_soft_limits.control_mode = (
                 ControlConfig_pb2.CARTESIAN_TRAJECTORY
             )
             joint_speed_soft_limits.joint_speed_soft_limits.extend(speed_limits)
-            self.control_config.SetJointSpeedSoftLimits(joint_speed_soft_limits)
+            cc.SetJointSpeedSoftLimits(joint_speed_soft_limits, options=opts)
         else:
             joint_speed_soft_limits = ControlConfig_pb2.JointSpeedSoftLimits()
             joint_speed_soft_limits.control_mode = ControlConfig_pb2.ANGULAR_TRAJECTORY
             joint_speed_soft_limits.joint_speed_soft_limits.extend(speed_limits)
-            self.control_config.SetJointSpeedSoftLimits(joint_speed_soft_limits)
+            cc.SetJointSpeedSoftLimits(joint_speed_soft_limits, options=opts)
             joint_acceleration_soft_limits = (
                 ControlConfig_pb2.JointAccelerationSoftLimits()
             )
@@ -550,11 +550,13 @@ class KinovaArm:
             joint_acceleration_soft_limits.joint_acceleration_soft_limits.extend(
                 acceleration_limits
             )
-            self.control_config.SetJointAccelerationSoftLimits(
-                joint_acceleration_soft_limits
+            cc.SetJointAccelerationSoftLimits(
+                joint_acceleration_soft_limits, options=opts
             )
 
     def choose_from_speed_presets(self, speed_preset: SpeedPreset):
+        cc = self.control_config
+        opts = self.control_send_options
         if not isinstance(speed_preset, SpeedPreset) or speed_preset in [
             SpeedPreset.DEFAULT,
             SpeedPreset.MAX,
@@ -584,25 +586,29 @@ class KinovaArm:
         cartesian_joystick_limits = ControlConfig_pb2.JointSpeedSoftLimits()
         cartesian_joystick_limits.control_mode = ControlConfig_pb2.CARTESIAN_JOYSTICK
         cartesian_joystick_limits.joint_speed_soft_limits.extend(speed_limits)
-        self.control_config.SetJointSpeedSoftLimits(cartesian_joystick_limits)
+        cc.SetJointSpeedSoftLimits(cartesian_joystick_limits, options=opts)
 
     def get_speed_preset(self):
         return self.speed_preset
 
     def set_max_joint_limits(self):
+        cc = self.control_config
+        opts = self.control_send_options
         self.speed_preset = SpeedPreset.MAX
-        speed_limits = self.control_config.GetKinematicHardLimits().joint_speed_limits
-        acceleration_limits = (
-            self.control_config.GetKinematicHardLimits().joint_acceleration_limits
-        )
+        speed_limits = cc.GetKinematicHardLimits(options=opts).joint_speed_limits
+        acceleration_limits = cc.GetKinematicHardLimits(
+            options=opts
+        ).joint_acceleration_limits
         self.set_joint_limits(speed_limits, acceleration_limits)
 
         cartesian_joystick_limits = ControlConfig_pb2.JointSpeedSoftLimits()
         cartesian_joystick_limits.control_mode = ControlConfig_pb2.CARTESIAN_JOYSTICK
         cartesian_joystick_limits.joint_speed_soft_limits.extend(speed_limits)
-        self.control_config.SetJointSpeedSoftLimits(cartesian_joystick_limits)
+        cc.SetJointSpeedSoftLimits(cartesian_joystick_limits, options=opts)
 
     def get_joint_limits(self):
+        cc = self.control_config
+        opts = self.control_send_options
         joint_limits = []
         control_mode_information = ControlConfig_pb2.ControlModeInformation()
         for control_mode in [
@@ -614,11 +620,13 @@ class KinovaArm:
         ]:
             control_mode_information.control_mode = control_mode
             joint_limits.append(
-                self.control_config.GetKinematicSoftLimits(control_mode_information)
+                cc.GetKinematicSoftLimits(control_mode_information, options=opts)
             )
         return joint_limits
 
     def reset_joint_limits(self):
+        cc = self.control_config
+        opts = self.control_send_options
         self.speed_preset = SpeedPreset.DEFAULT
         control_mode_information = ControlConfig_pb2.ControlModeInformation()
         for control_mode in [
@@ -629,54 +637,62 @@ class KinovaArm:
             ControlConfig_pb2.CARTESIAN_WAYPOINT_TRAJECTORY,
         ]:
             control_mode_information.control_mode = control_mode
-            self.control_config.ResetJointSpeedSoftLimits(control_mode_information)
+            cc.ResetJointSpeedSoftLimits(control_mode_information, options=opts)
         for control_mode in [
             ControlConfig_pb2.ANGULAR_JOYSTICK,
             ControlConfig_pb2.ANGULAR_TRAJECTORY,
         ]:
             control_mode_information.control_mode = control_mode
-            self.control_config.ResetJointAccelerationSoftLimits(
-                control_mode_information
-            )
+            cc.ResetJointAccelerationSoftLimits(control_mode_information, options=opts)
 
     def set_twist_linear_limit(self, limit):
+        cc = self.control_config
+        opts = self.control_send_options
         twist_linear_soft_limit = ControlConfig_pb2.TwistLinearSoftLimit()
         twist_linear_soft_limit.control_mode = ControlConfig_pb2.CARTESIAN_TRAJECTORY
         twist_linear_soft_limit.twist_linear_soft_limit = limit
-        self.control_config.SetTwistLinearSoftLimit(twist_linear_soft_limit)
+        cc.SetTwistLinearSoftLimit(twist_linear_soft_limit, options=opts)
 
     def set_max_twist_linear_limit(self):
-        limit = self.control_config.GetKinematicHardLimits().twist_linear  # 0.5
+        cc = self.control_config
+        opts = self.control_send_options
+        limit = cc.GetKinematicHardLimits(options=opts).twist_linear  # 0.5
         self.set_twist_linear_limit(limit)
 
     def reset_twist_linear_limit(self):
+        cc = self.control_config
+        opts = self.control_send_options
         control_mode_information = ControlConfig_pb2.ControlModeInformation()
         control_mode_information.control_mode = ControlConfig_pb2.CARTESIAN_TRAJECTORY
-        self.control_config.ResetTwistLinearSoftLimit(control_mode_information)
+        cc.ResetTwistLinearSoftLimit(control_mode_information, options=opts)
 
     # Rajat ToDo: Check how the following work:
     def pause_action(self):
-        self.base.PauseAction()
+        self.base.PauseAction(options=self.control_send_options)
 
     def resume_action(self):
-        self.base.ResumeAction()
+        self.base.ResumeAction(options=self.control_send_options)
 
     def stop_action(self):
-        self.base.StopAction()
+        self.base.StopAction(options=self.control_send_options)
 
     def stop(self):
-        self.base.Stop()
+        self.base.Stop(options=self.control_send_options)
 
     # Not using this as we haven't tested it
     # def apply_emergency_stop(self):
     #     self.base.ApplyEmergencyStop()
 
     def clear_faults(self, timeout=5.0):
-        if self.base.GetArmState().active_state == Base_pb2.ARMSTATE_IN_FAULT:
-            self.base.ClearFaults()
+        if (
+            self.base.GetArmState(options=self.control_send_options).active_state
+            == Base_pb2.ARMSTATE_IN_FAULT
+        ):
+            self.base.ClearFaults(options=self.control_send_options)
             deadline = time.perf_counter() + timeout
             while (
-                self.base.GetArmState().active_state != Base_pb2.ARMSTATE_SERVOING_READY
+                self.base.GetArmState(options=self.control_send_options).active_state
+                != Base_pb2.ARMSTATE_SERVOING_READY
             ):
                 if time.perf_counter() >= deadline:
                     raise TimeoutError(

--- a/hardware/arm_driver/arm_driver/arm_interface.py
+++ b/hardware/arm_driver/arm_driver/arm_interface.py
@@ -156,7 +156,7 @@ class KinovaArm:
             in [Common_pb2.BIG_ACTUATOR, Common_pb2.SMALL_ACTUATOR]
         ]
         self.send_options = RouterClientSendOptions()
-        self.send_options.timeout_ms = 3
+        self.send_options.timeout_ms = 50
 
         # clear faults
         self.clear_faults()
@@ -298,7 +298,7 @@ class KinovaArm:
         self.move_angular(intermediate_zero_config)
 
     def get_ee_force(self):
-        base_feedback = self.base_cyclic.RefreshFeedback()
+        base_feedback = self.base_cyclic.RefreshFeedback(options=self.send_options)
         ee_force = np.array(
             [
                 base_feedback.base.tool_external_wrench_force_x,
@@ -309,7 +309,7 @@ class KinovaArm:
         return ee_force
 
     def get_state(self):
-        base_feedback = self.base_cyclic.RefreshFeedback()
+        base_feedback = self.base_cyclic.RefreshFeedback(options=self.send_options)
 
         q, dq, tau = (
             np.zeros(self.actuator_count),

--- a/hardware/arm_driver/arm_driver/arm_interface.py
+++ b/hardware/arm_driver/arm_driver/arm_interface.py
@@ -105,7 +105,7 @@ class DeviceConnection:
 
 
 class KinovaArm:
-    ACTION_TIMEOUT_DURATION = 60
+    ACTION_TIMEOUT_DURATION = 20
 
     def __init__(self):
         # Check whether arm is connected
@@ -394,9 +394,9 @@ class KinovaArm:
     def move_angular_trajectory(self, trajectory_joint_angles, blocking=True):
         opts = self.control_send_options
         assert len(trajectory_joint_angles) > 0, "Invalid trajectory"
-        assert len(trajectory_joint_angles[0]) == self.actuator_count, (
-            "Invalid number of joint angles"
-        )
+        assert (
+            len(trajectory_joint_angles[0]) == self.actuator_count
+        ), "Invalid number of joint angles"
 
         jointPoses = [
             [math.degrees(angle) for angle in jointPose]
@@ -436,9 +436,9 @@ class KinovaArm:
             print(result.trajectory_error_report)
 
     def move_angular(self, joint_angles, blocking=True):
-        assert len(joint_angles) == self.actuator_count, (
-            "Invalid number of joint angles"
-        )
+        assert (
+            len(joint_angles) == self.actuator_count
+        ), "Invalid number of joint angles"
 
         # Create action
         action = Base_pb2.Action()


### PR DESCRIPTION
## Related Issue
Closes #138
## Summary
Hardens all Kortex API communication in the arm driver stack to handle network timeouts gracefully under high network load. Builds on the initial `BaseCyclic` timeout fix by extending coverage to every remaining runtime Kortex API call and every unprotected call site in the ROS node layer.
## Changes
- **`arm_interface.py`**: Added `options=self.control_send_options` (200ms) to all remaining runtime `self.base.*` TCP calls — `Stop`, `StopAction`, `PauseAction`, `ResumeAction`, `ClearFaults`, `GetArmState`, `ReadAllActions`, `ExecuteActionFromReference`, `ExecuteAction`, `ValidateWaypointList`, `ExecuteWaypointTrajectory`, `SendGripperCommand`
- **`arm_interface.py`**: Added `options=self.control_send_options` to all `control_config.*` calls reachable from service handlers (`SetJointSpeedSoftLimits`, `SetJointAccelerationSoftLimits`, `GetKinematicHardLimits`, `GetKinematicSoftLimits`, `Reset*`, `SetTwistLinearSoftLimit`, `ResetTwistLinearSoftLimit`)
- **`arm_interface.py`**: Replaced `self.stop()` + `self.disconnect()` in `move_angular()` and `move_cartesian()` error paths with `self.stop()` + `raise RuntimeError(...)` — arm connection is now preserved on position error
- **`arm_driver.py`**: Wrapped `self._arm.stop()` in `_transition_to()` with try/except so state transitions (including e-stop) always complete even if the arm is unresponsive
- **`arm_driver.py`**: Added `if self._arm:` null guards and try/except to `_handle_joint_position()` and `_handle_cartesian_pose()` (matching the existing pattern in `_handle_twist()`)
- **`arm_driver.py`**: Added try/except to `_handle_twist()` to catch send failures
- **`arm_driver.py`**: Added try/except to `_on_set_speed_preset()` around `choose_from_speed_presets()` — returns failure response on timeout
- **`arm_driver.py`**: Added inner try/except for `get_state()` inside action feedback loops in `_run_reference_action()` and `_on_execute_trajectory()` — transient UDP timeouts now skip one feedback cycle instead of aborting the entire action
- **`arm_driver.py`**: Added `ArmState.ERROR` check to `_on_execute_trajectory()` feedback loop to detect e-stop during trajectory execution (matches existing check in `_run_reference_action()`)
- - 
## Test Procedures
1. **Normal operation**: Launch `arm_driver` node. Verify 100 Hz `/arm/joint_states` publishing is stable for 5+ minutes under normal network conditions. No timeout warnings in logs.
2. **Induced timeout — publisher (100 Hz loop)**: While node is running, briefly disconnect/reconnect the arm's Ethernet cable (~1–2 seconds). Verify: node logs throttled `RefreshFeedback timed out` warning, does **not** crash, resumes publishing cleanly after reconnect.

## Test Results
<!-- To be filled in by tester on hardware -->
## Checklist
- [ ] Merged latest `dev` into this branch and resolved all conflicts
- [ ] Documentation updated to reflect all changes in code and/or specifications
- [ ] Tested on hardware (or documented why hardware testing was not applicable)
- [ ] Reviewer assigned