### PR TITLE
fixed serial message to start self-leveling mode

### DIFF
--- a/hardware/rammp_prototype_driver/rammp_prototype_driver/MEBot_control_node.py
+++ b/hardware/rammp_prototype_driver/rammp_prototype_driver/MEBot_control_node.py
@@ -628,11 +628,9 @@ class MEBotControlNode(Node):
 
     def self_level_enable_callback(self, request, response):
         if request.data:
-            self.write_serial_data("s\n")
-            pass
+            self.write_serial_data("L1:1\n")
         else:
-            self.write_serial_data("r\n")
-            pass
+            self.write_serial_data("L1:0\n")
 
         response.success = True  # just acknowledges request recieved and sent
         return response


### PR DESCRIPTION
## Related Issue

## Summary

<!-- Brief description of what this PR adds or fixes -->

Fixes issue with self-leveling mode not starting from ROS

## Changes

<!-- List the key changes made -->

- Changed serial message sent to Teensy during self-leveling callback

## Test Procedures

<!-- How did you test this? Be specific enough that a reviewer can reproduce. -->

1. Run ```ros2 launch rammp_prototype_driver control_node.launch.py```
2. In another terminal, run ```ros2 service call base/self_level_enable std_srvs/srv/SetBool "{data: true}"```
3. Check that robot enters self-leveling mode
4. Run ```ros2 service call base/self_level_enable std_srvs/srv/SetBool "{data: false}"```
5. Check that robot has left self-leveling mode

## Test Results

<!-- What did you observe? Include any relevant data, screenshots, or serial output. -->

Robot works as intended

## Checklist

- [x] Merged latest `dev` into this branch and resolved all conflicts
- [x] Documentation updated to reflect all changes in code and/or specifications
- [x] Tested on hardware (or documented why hardware testing was not applicable)
- [x] Reviewer assigned
