### PR TITLE
Feature/13 image compression clean

### DIFF
--- a/core/rammp_prototype_behavior/package.xml
+++ b/core/rammp_prototype_behavior/package.xml
@@ -18,6 +18,8 @@
   <depend>gui_interfaces</depend>
   <depend>geometry_msgs</depend>
   <depend>sensor_msgs</depend>
+  <depend>image_transport</depend>
+  <depend>compressed_image_transport</depend>
 
   <exec_depend>python3-scipy</exec_depend>
   <exec_depend>python3-pinocchio</exec_depend>

--- a/core/rammp_prototype_bringup/launch/camera.launch.py
+++ b/core/rammp_prototype_bringup/launch/camera.launch.py
@@ -143,6 +143,42 @@ def generate_launch_description():
                     ],
                 )
             )
+            actions.append(
+                Node(
+                    package="image_transport",
+                    executable="republish",
+                    name="wrist_color_republish",
+                    arguments=["raw", "compressed"],
+                    remappings=[
+                        ("in", "/camera/wrist/color/image_raw"),
+                        (
+                            "out/compressed",
+                            "/camera/wrist/color/image_raw/compressed_png",
+                        ),
+                    ],
+                    parameters=[{"out.format": "png", "out.png_level": 6}],
+                    output="screen",
+                )
+            )
+
+            # Depth
+            actions.append(
+                Node(
+                    package="image_transport",
+                    executable="republish",
+                    name="wrist_depth_republish",
+                    arguments=["raw", "compressed"],
+                    remappings=[
+                        ("in", "/camera/wrist/depth/image_rect_raw"),
+                        (
+                            "out/compressed",
+                            "/camera/wrist/depth/image_rect_raw/compressed_png",
+                        ),
+                    ],
+                    parameters=[{"out.format": "png", "out.png_level": 6}],
+                    output="screen",
+                )
+            )
 
         # ── Nav1 camera (Orbbec Gemini 336L) ──────────────────────────────
         # PushRosNamespace("camera") prepends /camera to all topics published

--- a/core/rammp_prototype_bringup/launch/camera.launch.py
+++ b/core/rammp_prototype_bringup/launch/camera.launch.py
@@ -169,10 +169,10 @@ def generate_launch_description():
                     name="wrist_depth_republish",
                     arguments=["raw", "compressed"],
                     remappings=[
-                        ("in", "/camera/wrist/depth/image_rect_raw"),
+                        ("in", "/camera/wrist/aligned_depth_to_color/image_raw"),
                         (
                             "out/compressed",
-                            "/camera/wrist/depth/image_rect_raw/compressed_png",
+                            "/camera/wrist/aligned_depth_to_color/image_raw/compressed_png",
                         ),
                     ],
                     parameters=[{"out.format": "png", "out.png_level": 6}],


### PR DESCRIPTION
## Related Issue

Closes #13

## Summary

<!-- Brief description of what this PR adds or fixes -->

Adds image compression for camera frames sent to Cornell laptop. Includes lossy (JPEG) and lossless (PNG) compression, further testing is required to decide which is more feasible to use.

## Changes

<!-- List the key changes made -->

- Add image_transport packages to rosdep
- Republish camera topics as compressed camera topics

## Test Procedures

<!-- How did you test this? Be specific enough that a reviewer can reproduce. -->

1. Ran ```ros2 topic hz {name of topic}``` and ```ros2 topic bw {name of topic}``` to evaluate compression effectiveness and latency
2. Will do further testing with Cornell's code in the loop

## Test Results

<!-- What did you observe? Include any relevant data, screenshots, or serial output. -->

Uncompressed and JPEG compression had similar publishing rates at around 30 hz on average, while PNG compression was around 12 hz. Compression reduced bandwidth from ~30 Mb/s to a little less than 1 Mb/s for JPEG and around 1.7 Mb/s for PNG.

## Checklist

- [ ] Merged latest `dev` into this branch and resolved all conflicts
- [ ] Documentation updated to reflect all changes in code and/or specifications
- [ ] Tested on hardware (or documented why hardware testing was not applicable)
- [ ] Reviewer assigned
