### PR TITLE
BUG FIX: Luci always sending joystick command

### DIFF
--- a/core/rammp_prototype_behavior/config/node_name.json
+++ b/core/rammp_prototype_behavior/config/node_name.json
@@ -16,7 +16,7 @@
       "name": "/cup_stabilizer_node"
     },
     {
-      "name": "/base_control_node"
+      "name": "/base/base_control_node"
     },
     {
       "name": "/perception_curb_detection_node"

--- a/core/rammp_prototype_behavior/launch/mock.launch.py
+++ b/core/rammp_prototype_behavior/launch/mock.launch.py
@@ -5,11 +5,11 @@ from launch_ros.actions import Node
 def generate_launch_description():
     return LaunchDescription(
         [
-            Node(
-                package="rammp_prototype_behavior",
-                executable="mock_arm_driver",
-                output="screen",
-            ),
+            # Node(
+            #     package="rammp_prototype_behavior",
+            #     executable="mock_arm_driver",
+            #     output="screen",
+            # ),
             Node(
                 package="rammp_prototype_behavior",
                 executable="mock_drinking_node",
@@ -25,11 +25,11 @@ def generate_launch_description():
                 executable="mock_cup_stabilizer",
                 output="screen",
             ),
-            Node(
-                package="rammp_prototype_behavior",
-                executable="mock_chair_control",
-                output="screen",
-            ),
+            # Node(
+            #     package="rammp_prototype_behavior",
+            #     executable="mock_chair_control",
+            #     output="screen",
+            # ),
             Node(
                 package="rammp_prototype_behavior",
                 executable="mock_curb_detection",

--- a/core/rammp_prototype_behavior/rammp_prototype_behavior/mocks/mock_chair_control_node.py
+++ b/core/rammp_prototype_behavior/rammp_prototype_behavior/mocks/mock_chair_control_node.py
@@ -57,7 +57,7 @@ class SerialField(IntEnum):
 
 class BaseControlNode(Node):
     def __init__(self):
-        super().__init__("base_control_node")
+        super().__init__("base/base_control_node")
 
         # # serial init
         # self.declare_parameter("serial_port", "/dev/ttyACM0")

--- a/hardware/rammp_prototype_driver/config/curb_ascending.json
+++ b/hardware/rammp_prototype_driver/config/curb_ascending.json
@@ -38,10 +38,10 @@
       "duration_ms": 1000,
       "label": "Raise FC, ML, MR, and RC so FC can reach curb height",
       "motor_durations": [
+        3000,
         null,
-        null,
-        null,
-        null,
+        1000,
+        1000,
         null,
         null,
         null,
@@ -60,8 +60,8 @@
       "targets": [
         864.0,
         105.0,
-        380.0,
-        392.0,
+        430.0,
+        370.0,
         204.0,
         122.0,
         0.0,
@@ -72,7 +72,7 @@
       "duration_ms": 1000,
       "label": "Drive to curb",
       "motor_durations": [
-        null,
+        4000,
         null,
         null,
         null,
@@ -94,8 +94,8 @@
       "targets": [
         861.0,
         105.0,
-        377.0,
-        390.0,
+        430.0,
+        370.0,
         192.0,
         127.0,
         3200.0,
@@ -128,8 +128,8 @@
       "targets": [
         860.0,
         105.0,
-        378.0,
-        384.0,
+        430.0,
+        370.0,
         12661.0,
         12615.0,
         0.0,
@@ -142,8 +142,8 @@
       "motor_durations": [
         null,
         null,
-        null,
-        null,
+        2000,
+        1500,
         null,
         null,
         null,
@@ -162,8 +162,8 @@
       "targets": [
         860.0,
         105.0,
-        21.0,
-        30.0,
+        0.0,
+        0.0,
         12644.0,
         12617.0,
         0.0,
@@ -176,8 +176,8 @@
       "motor_durations": [
         null,
         null,
-        null,
-        null,
+        2000,
+        2000,
         2000,
         2000,
         null,
@@ -196,10 +196,10 @@
       "targets": [
         860.0,
         105.0,
-        45.0,
-        45.0,
-        6000.0,
-        6000.0,
+        0.0,
+        0.0,
+        10000.0,
+        10000.0,
         0.0,
         0.0
       ]
@@ -208,7 +208,7 @@
       "duration_ms": 1000,
       "label": "Move carriages forward while driving",
       "motor_durations": [
-        null,
+        5000,
         null,
         null,
         null,
@@ -230,11 +230,11 @@
       "targets": [
         860.0,
         105.0,
-        49.0,
-        48.0,
-        101.0,
-        93.0,
-        4000.0,
+        0.0,
+        0.0,
+        6000.0,
+        6000.0,
+        5000.0,
         0.0
       ]
     },
@@ -264,8 +264,8 @@
       "targets": [
         860.0,
         105.0,
-        47.0,
-        46.0,
+        0.0,
+        0.0,
         12622.0,
         12620.0,
         0.0,
@@ -278,8 +278,8 @@
       "motor_durations": [
         null,
         null,
-        null,
-        null,
+        1000,
+        1000,
         null,
         null,
         null,
@@ -299,7 +299,7 @@
         367.0,
         105.0,
         199.0,
-        200.0,
+        175.0,
         12600.0,
         12595.0,
         0.0,
@@ -310,7 +310,7 @@
       "duration_ms": 1000,
       "label": "Drive forward a little",
       "motor_durations": [
-        null,
+        6000,
         null,
         null,
         null,
@@ -333,7 +333,7 @@
         363.0,
         110.0,
         197.0,
-        199.0,
+        175.0,
         12600.0,
         12595.0,
         3500.0,
@@ -342,12 +342,12 @@
     },
     {
       "duration_ms": 1000,
-      "label": "Lower RC to catch weight when shifting weight backwards",
+      "label": "Lower RC and FC and lift main wheels",
       "motor_durations": [
         null,
         null,
-        null,
-        null,
+        2000,
+        2000,
         null,
         null,
         null,
@@ -364,10 +364,10 @@
         true
       ],
       "targets": [
-        633.0,
-        103.0,
-        202.0,
-        210.0,
+        300.0,
+        200.0,
+        0.0,
+        0.0,
         12606.0,
         12610.0,
         0.0,
@@ -376,14 +376,14 @@
     },
     {
       "duration_ms": 1000,
-      "label": "Move carriages forward while driving",
+      "label": "Move carriages forward",
       "motor_durations": [
         null,
         null,
         null,
         null,
-        1000,
-        1000,
+        3000,
+        3000,
         1000,
         null
       ],
@@ -398,13 +398,13 @@
         true
       ],
       "targets": [
-        633.0,
-        105.0,
-        199.0,
+        300.0,
         200.0,
+        0.0,
+        0.0,
         101.0,
         93.0,
-        7500.0,
+        0.0,
         0.0
       ]
     },
@@ -414,8 +414,8 @@
       "motor_durations": [
         null,
         null,
-        null,
-        null,
+        2000,
+        2000,
         null,
         null,
         null,
@@ -433,15 +433,15 @@
       ],
       "targets": [
         366.0,
-        105.0,
+        21.0,
         201.0,
-        202.0,
-        502.0,
+        174.0,
+        101.0,
         96.0,
         0.0,
         0.0
       ]
     }
   ],
-  "name": "curb_climbing_wip"
+  "name": "curb_climbing_final"
 }

--- a/hardware/rammp_prototype_driver/config/curb_descending.json
+++ b/hardware/rammp_prototype_driver/config/curb_descending.json
@@ -25,7 +25,7 @@
       ],
       "targets": [
         370.0,
-        20.0,
+        30.0,
         191.0,
         175.0,
         130.0,
@@ -38,13 +38,13 @@
       "duration_ms": 1000,
       "label": "Drive forward a little",
       "motor_durations": [
+        6000,
         null,
         null,
         null,
         null,
         null,
-        null,
-        null,
+        3000,
         null
       ],
       "relative": [
@@ -59,7 +59,7 @@
       ],
       "targets": [
         368.0,
-        21.0,
+        30.0,
         190.0,
         173.0,
         173.0,
@@ -74,8 +74,8 @@
       "motor_durations": [
         null,
         3000,
-        null,
-        null,
+        2000,
+        2000,
         null,
         null,
         null,
@@ -93,7 +93,7 @@
       ],
       "targets": [
         369.0,
-        517.0,
+        485.0,
         69.0,
         69.0,
         112.0,
@@ -108,8 +108,8 @@
       "motor_durations": [
         null,
         null,
-        null,
-        null,
+        2000,
+        2000,
         null,
         null,
         null,
@@ -142,8 +142,8 @@
       "motor_durations": [
         null,
         null,
-        null,
-        null,
+        2000,
+        2000,
         null,
         null,
         null,
@@ -160,12 +160,12 @@
         true
       ],
       "targets": [
-        378.0,
-        483.0,
-        20.0,
-        21.0,
-        12624.0,
-        12578.0,
+        357.7,
+        485.0,
+        19.0,
+        18.0,
+        12600.0,
+        12581.0,
         0.0,
         0.0
       ]
@@ -195,7 +195,7 @@
       ],
       "targets": [
         380.0,
-        479.0,
+        485.0,
         20.0,
         21.0,
         155.0,
@@ -210,8 +210,8 @@
       "motor_durations": [
         null,
         null,
-        null,
-        null,
+        2000,
+        2000,
         null,
         null,
         null,
@@ -229,9 +229,9 @@
       ],
       "targets": [
         380.0,
-        483.0,
+        485.0,
         364.0,
-        399.0,
+        300.0,
         155.0,
         79.0,
         0.0,
@@ -263,9 +263,9 @@
       ],
       "targets": [
         380.0,
-        484.0,
+        485.0,
         368.0,
-        403.0,
+        300.0,
         12598.0,
         12600.0,
         0.0,
@@ -277,7 +277,7 @@
       "label": "Driving forward while raising RC",
       "motor_durations": [
         null,
-        null,
+        5000,
         null,
         null,
         null,
@@ -297,12 +297,12 @@
       ],
       "targets": [
         13.0,
-        486.0,
+        485.0,
         368.0,
-        398.0,
+        300.0,
         12598.0,
         12600.0,
-        4000.0,
+        8000.0,
         0.0
       ]
     },
@@ -312,8 +312,8 @@
       "motor_durations": [
         null,
         null,
-        null,
-        null,
+        2000,
+        2000,
         null,
         null,
         null,
@@ -331,9 +331,9 @@
       ],
       "targets": [
         746.0,
-        466.0,
-        293.0,
-        292.0,
+        485.0,
+        368.0,
+        300.0,
         12620.0,
         12580.0,
         0.0,
@@ -342,7 +342,41 @@
     },
     {
       "duration_ms": 1000,
-      "label": "Move carriages forward while driving",
+      "label": "Raise ML and MR",
+      "motor_durations": [
+        null,
+        null,
+        2000,
+        2000,
+        null,
+        null,
+        null,
+        null
+      ],
+      "relative": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true
+      ],
+      "targets": [
+        300.0,
+        200.0,
+        80.0,
+        65.0,
+        12620.0,
+        12580.0,
+        0.0,
+        0.0
+      ]
+    },
+    {
+      "duration_ms": 1000,
+      "label": "Move carriages forward",
       "motor_durations": [
         null,
         null,
@@ -364,13 +398,13 @@
         true
       ],
       "targets": [
-        853.0,
-        502.0,
-        368.0,
-        397.0,
+        300.0,
+        200.0,
+        80.0,
+        65.0,
         136.0,
         96.0,
-        8000.0,
+        0.0,
         0.0
       ]
     },
@@ -378,10 +412,10 @@
       "duration_ms": 1000,
       "label": "Go back to self leveling mode",
       "motor_durations": [
-        null,
-        null,
-        null,
-        null,
+        3000,
+        2000,
+        1000,
+        1000,
         null,
         null,
         null,
@@ -409,5 +443,5 @@
       ]
     }
   ],
-  "name": "curb_descending_inchworm"
+  "name": "curb_descending_final"
 }

--- a/hardware/rammp_prototype_driver/firmware/Base/Base.ino
+++ b/hardware/rammp_prototype_driver/firmware/Base/Base.ino
@@ -34,7 +34,7 @@
 #define DRIVE_DEADZONE_TICKS 300.0f
 
 #define CAL_NUM_MOTORS 6
-#define CAL_MIN_DRIVE_MS 3000
+#define CAL_MIN_DRIVE_MS 6000
 #define CAL_VEL_THRESHOLD 2.0f
 // TODO: Make DEBUG_MODE runtime-configurable via serial command
 

--- a/hardware/rammp_prototype_driver/launch/control_node.launch.py
+++ b/hardware/rammp_prototype_driver/launch/control_node.launch.py
@@ -25,7 +25,7 @@ def generate_launch_description():
             Node(
                 package="rammp_prototype_driver",
                 executable="control_node",
-                name="MEBot_control_node",
+                name="base_control_node",
                 namespace=LaunchConfiguration("namespace"),
                 output="screen",
                 emulate_tty=True,

--- a/hardware/rammp_prototype_driver/rammp_prototype_driver/MEBot_control_node.py
+++ b/hardware/rammp_prototype_driver/rammp_prototype_driver/MEBot_control_node.py
@@ -303,8 +303,6 @@ class MEBotControlNode(Node):
         self.luci_heartbeat_timer = self.create_timer(0.005, self._send_joystick)
         self.luci_heartbeat_timer.cancel()  # start with heartbeat disabled until LUCI control is enabled
 
-        self.luci_heartbeat_timer.cancel()
-
         # self.imu_publisher = self.create_publisher(Imu, "imu", 10)
         # self.imu_timer = self.create_timer(self.publish_rate, self.publish_imu_data)
 
@@ -672,9 +670,9 @@ class MEBotControlNode(Node):
 
     def drive_enable_callback(self, request, response):
         if request.data:
-            self.send_set_luci()
-        else:
             self.send_remove_luci()
+        else:
+            self.send_set_luci()
 
         response.success = True  # just acknowledges request recieved and sent
         return response

--- a/hardware/rammp_prototype_driver/rammp_prototype_driver/MEBot_control_node.py
+++ b/hardware/rammp_prototype_driver/rammp_prototype_driver/MEBot_control_node.py
@@ -75,7 +75,7 @@ SEAT_DELTAS: dict[int, list[float]] = {
     SeatCommand.TILT_BACK: [0.0, 0.0, 40.0, 40.0, 0.0, 0.0, 0.0, 0.0],
     SeatCommand.LATERAL_LEFT: [0.0, 0.0, -30.0, 30.0, 0.0, 0.0, 0.0, 0.0],
     SeatCommand.LATERAL_RIGHT: [0.0, 0.0, 30.0, -30.0, 0.0, 0.0, 0.0, 0.0],
-    SeatCommand.RESET: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    SeatCommand.RESET: [233.0, 25.0, 212.0, 192.0, 101.0, 95.0, 0.0, 0.0],
 }
 
 
@@ -244,6 +244,8 @@ class MEBotControlNode(Node):
         self._init_subscribers()
         self._init_publishers()
 
+        self.send_remove_luci()
+
     def _init_services(self):
         # services
         self.drive_enable_service = self.create_service(
@@ -302,6 +304,8 @@ class MEBotControlNode(Node):
         self.luci_js_publisher = self.create_publisher(LuciJoystick, JOYSTICK_TOPIC, 10)
 
         self.luci_heartbeat_timer = self.create_timer(0.005, self._send_joystick)
+
+        self.luci_heartbeat_timer.cancel()
 
         # self.imu_publisher = self.create_publisher(Imu, "imu", 10)
         # self.imu_timer = self.create_timer(self.publish_rate, self.publish_imu_data)
@@ -406,7 +410,7 @@ class MEBotControlNode(Node):
         # State
         self.state = int(data[SerialField.STATE])
 
-        self.fb_pwm = int(100.0 * float(SerialField.FB_PWM))
+        self.fb_pwm = int(100.0 * float(data[SerialField.FB_PWM]))
 
     def publish_joint_states(self):
         msg = JointState()
@@ -557,12 +561,16 @@ class MEBotControlNode(Node):
         request = Empty.Request()
         future = self.set_auto_remote_client.call_async(request)
         future.add_done_callback(self.luci_req_done)
+
+        self.luci_heartbeat_timer.reset()
         return future
 
     def send_remove_luci(self):
         request = Empty.Request()
         future = self.remove_auto_remote_client.call_async(request)
         future.add_done_callback(self.luci_req_done)
+
+        self.luci_heartbeat_timer.cancel()
         return future
 
     def luci_req_done(self, future):
@@ -642,6 +650,7 @@ class MEBotControlNode(Node):
             if goal.is_cancel_requested:
                 goal.canceled()
                 result.success = False
+                self.send_remove_luci()
                 return result
 
             feedback_msg.progress = (

--- a/hardware/rammp_prototype_driver/rammp_prototype_driver/MEBot_control_node.py
+++ b/hardware/rammp_prototype_driver/rammp_prototype_driver/MEBot_control_node.py
@@ -158,7 +158,7 @@ class SystemState(IntEnum):
 
 class MEBotControlNode(Node):
     def __init__(self):
-        super().__init__("/base_control_node")
+        super().__init__("base_control_node")
 
         # serial init
         self.declare_parameter("serial_port", "/dev/ttyACM0")

--- a/hardware/rammp_prototype_driver/rammp_prototype_driver/MEBot_control_node.py
+++ b/hardware/rammp_prototype_driver/rammp_prototype_driver/MEBot_control_node.py
@@ -648,6 +648,7 @@ class MEBotControlNode(Node):
                 goal.canceled()
                 result.success = False
                 self.send_remove_luci()
+                self.write_serial_data(ProtocolEncoder.enter_sequence_mode(False))
                 return result
             time.sleep(0.01)
 
@@ -656,6 +657,7 @@ class MEBotControlNode(Node):
                 goal.canceled()
                 result.success = False
                 self.send_remove_luci()
+                self.write_serial_data(ProtocolEncoder.enter_sequence_mode(False))
                 return result
 
             feedback_msg.progress = (
@@ -675,6 +677,7 @@ class MEBotControlNode(Node):
         self.seq_mode = 0
 
         self.send_remove_luci()
+        self.write_serial_data(ProtocolEncoder.enter_sequence_mode(False))
         return result
 
     def drive_enable_callback(self, request, response):

--- a/hardware/rammp_prototype_driver/rammp_prototype_driver/MEBot_control_node.py
+++ b/hardware/rammp_prototype_driver/rammp_prototype_driver/MEBot_control_node.py
@@ -558,6 +558,7 @@ class MEBotControlNode(Node):
             self.write_serial_data("K0\n")
 
     def send_set_luci(self):
+        self.get_logger().info("Setting luci")
         request = Empty.Request()
         future = self.set_auto_remote_client.call_async(request)
         future.add_done_callback(self.luci_req_done)
@@ -566,6 +567,7 @@ class MEBotControlNode(Node):
         return future
 
     def send_remove_luci(self):
+        self.get_logger().info("Removing luci")
         request = Empty.Request()
         future = self.remove_auto_remote_client.call_async(request)
         future.add_done_callback(self.luci_req_done)
@@ -630,12 +632,12 @@ class MEBotControlNode(Node):
         if goal.request.direction == 1:
             json_path = (
                 get_package_share_directory("rammp_prototype_driver")
-                + "/config/dry_run_seq.json"
+                + "/config/curb_ascending.json"
             )
         else:
             json_path = (
                 get_package_share_directory("rammp_prototype_driver")
-                + "/config/dry_run_seq_2.json"
+                + "/config/curb_descending.json"
             )
 
         keyframes = _load_keyframes_from_json(json_path)
@@ -649,15 +651,21 @@ class MEBotControlNode(Node):
                 result.success = False
                 self.send_remove_luci()
                 self.write_serial_data(ProtocolEncoder.enter_sequence_mode(False))
+                self.write_serial_data("z\n")
+                self.write_serial_data("c\n")
                 return result
             time.sleep(0.01)
 
         while self.current_seq != self.seq_length and self.seq_mode != 0:
+            self.get_logger().info(f"Current sequence: {self.current_seq}")
+
             if goal.is_cancel_requested:
                 goal.canceled()
                 result.success = False
                 self.send_remove_luci()
                 self.write_serial_data(ProtocolEncoder.enter_sequence_mode(False))
+                self.write_serial_data("z\n")
+                self.write_serial_data("c\n")
                 return result
 
             feedback_msg.progress = (

--- a/hardware/rammp_prototype_driver/rammp_prototype_driver/MEBot_control_node.py
+++ b/hardware/rammp_prototype_driver/rammp_prototype_driver/MEBot_control_node.py
@@ -1,27 +1,24 @@
+import json
 import math
 import time
 from enum import IntEnum
-from std_srvs.srv import Empty
-from rclpy.executors import MultiThreadedExecutor
-import json
-from ament_index_python.packages import get_package_share_directory
+
+import diagnostic_updater
 import rclpy
 import serial
-from rammp_prototype_interfaces.action import CurbTraverse
-from rammp_prototype_interfaces.action import Calibration
-from rammp_prototype_interfaces.msg import SeatCommand
+from ament_index_python.packages import get_package_share_directory
+from diagnostic_msgs.msg import DiagnosticStatus
 from luci_messages.msg import LuciJoystick
-
-from rammp_prototype_interfaces.msg import RAMMPPrototypeState
+from rammp_prototype_interfaces.action import Calibration, CurbTraverse
+from rammp_prototype_interfaces.msg import RAMMPPrototypeState, SeatCommand
 from rclpy.action import ActionServer
+from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
 from sensor_msgs.msg import Imu, JointState
 from std_msgs.msg import Bool
-from std_srvs.srv import SetBool
-import diagnostic_updater
-from diagnostic_msgs.msg import DiagnosticStatus
+from std_srvs.srv import Empty, SetBool
 
-from .keyframe import Keyframe, NUM_MOTORS
+from .keyframe import NUM_MOTORS, Keyframe
 from .protocol import ProtocolEncoder
 
 # LUCI STUFF
@@ -148,7 +145,7 @@ class SerialField(IntEnum):
 
 class MEBotControlNode(Node):
     def __init__(self):
-        super().__init__("MEBot_control_node")
+        super().__init__("/base_control_node")
 
         # serial init
         self.declare_parameter("serial_port", "/dev/ttyACM0")
@@ -304,6 +301,7 @@ class MEBotControlNode(Node):
         self.luci_js_publisher = self.create_publisher(LuciJoystick, JOYSTICK_TOPIC, 10)
 
         self.luci_heartbeat_timer = self.create_timer(0.005, self._send_joystick)
+        self.luci_heartbeat_timer.cancel()  # start with heartbeat disabled until LUCI control is enabled
 
         self.luci_heartbeat_timer.cancel()
 

--- a/hardware/rammp_prototype_driver/rammp_prototype_driver/MEBot_control_node.py
+++ b/hardware/rammp_prototype_driver/rammp_prototype_driver/MEBot_control_node.py
@@ -11,7 +11,7 @@ from diagnostic_msgs.msg import DiagnosticStatus
 from luci_messages.msg import LuciJoystick
 from rammp_prototype_interfaces.action import Calibration, CurbTraverse
 from rammp_prototype_interfaces.msg import RAMMPPrototypeState, SeatCommand
-from rclpy.action import ActionServer
+from rclpy.action import ActionServer, CancelResponse
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
 from sensor_msgs.msg import Imu, JointState
@@ -264,7 +264,11 @@ class MEBotControlNode(Node):
     def _init_actions(self):
         # actions
         self.curb_traverse_action = ActionServer(
-            self, CurbTraverse, "curb_traverse", self.curb_traverse_action_callback
+            self,
+            CurbTraverse,
+            "curb_traverse",
+            self.curb_traverse_action_callback,
+            cancel_callback=lambda _: CancelResponse.ACCEPT,
         )
 
         self.calibrate_action = ActionServer(
@@ -640,6 +644,11 @@ class MEBotControlNode(Node):
         self.send_sequence(keyframes, auto_run=True)
 
         while self.seq_mode == 0:
+            if goal.is_cancel_requested:
+                goal.canceled()
+                result.success = False
+                self.send_remove_luci()
+                return result
             time.sleep(0.01)
 
         while self.current_seq != self.seq_length and self.seq_mode != 0:


### PR DESCRIPTION
## Related Issue

Closes #181 

## Summary

Bug fix: LUCI was always sending forward commands to the robot. This was caused by incorrectly indexing syntax reading joystick commands from Teensy


## Changes

- Fix incorrect indexing syntax
- Update luci heartbeat timer to only run when luci is controlling rnet
- Change reset position for the base
- Fix edge case: release control of rnet if curb traverse action is canceled

## Test Procedures

1. Attempted to send joystick commands while LUCI was not controlling the joystick -> **Result**: wheels did not move, user had full control
2. Attempted to send joystick commands while LUCI was controlling joystick -> **Result**: wheels did move
3. Tested a full curb traverse sequence to ensure that the LUCI allowed correct control of the wheels

## Checklist

- [x] Merged latest `dev` into this branch and resolved all conflicts
- [x] Documentation updated to reflect all changes in code and/or specifications
- [x] Tested on hardware (or documented why hardware testing was not applicable)
- [x] Reviewer assigned
