### PR TITLE
removed drive wheel zeroing when entering sequence mode

### DIFF
--- a/hardware/rammp_prototype_driver/firmware/Base/src/SequencePlayer/SequencePlayer.cpp
+++ b/hardware/rammp_prototype_driver/firmware/Base/src/SequencePlayer/SequencePlayer.cpp
@@ -145,18 +145,6 @@ void sequenceEnter(Motor *motors[SEQ_NUM_MOTORS]) {
   seq_settling = false;
   seq_auto_run = false;
 
-  // Zero drive wheel positions so closed-loop control starts from a known
-  // origin.  This prevents float precision issues from accumulating over long
-  // drives and ensures repeatable sequence behavior.
-  for (int i = SEQ_NUM_POS_MOTORS; i < SEQ_NUM_MOTORS; i++) {
-    motors[i]->current_pos = 0.0f;
-    motors[i]->prev_pos = 0.0f;
-    motors[i]->current_vel = 0.0f;
-    motors[i]->prev_vel = 0.0f;
-    motors[i]->pos_pid.reset();
-    motors[i]->vel_pid.reset();
-  }
-
   // ALL motors — including drive wheels — run position control during
   // sequences.
   for (int i = 0; i < SEQ_NUM_MOTORS; i++) {


### PR DESCRIPTION
## Related Issue

Closes #221 

## Summary

<!-- Brief description of what this PR adds or fixes -->

Fixes bug where drive wheels will drive when switching to sequence editor mode.

## Changes

<!-- List the key changes made -->

- Removed zeroing of drive wheels

## Test Procedures

<!-- How did you test this? Be specific enough that a reviewer can reproduce. -->

1. Tested on PID tuner GUI. Make sure D_FB encoder reading is not 0. Go to Sequences, load a sequence, then Send to Robot. See if chair drives after pressing button.

## Test Results

<!-- What did you observe? Include any relevant data, screenshots, or serial output. -->

Chair no longer drives after changing to Sequence Mode.

## Checklist

- [x] Merged latest `dev` into this branch and resolved all conflicts
- [x] Documentation updated to reflect all changes in code and/or specifications
- [x] Tested on hardware (or documented why hardware testing was not applicable)
- [x] Reviewer assigned
