### PR TITLE
Bug/fixing carriage return activation

### DIFF
--- a/hardware/pid_tuner/data/data_store.py
+++ b/hardware/pid_tuner/data/data_store.py
@@ -388,6 +388,7 @@ class DataStore(QObject):
         self._drive_lr_vel: float = 0.0
         self._drive_fb_pwm: float = 0.0
         self._drive_lr_pwm: float = 0.0
+        self._carriage_return_direction: int = 0
         self._raw_ml_enc_pos: float = 0.0
         self._raw_mr_enc_pos: float = 0.0
         self._raw_ml_enc_vel: float = 0.0
@@ -634,6 +635,10 @@ class DataStore(QObject):
         return self._drive_lr_pwm
 
     @property
+    def carriage_return_direction(self) -> int:
+        return self._carriage_return_direction
+
+    @property
     def odrive_r_pos(self) -> float:
         return self._odrive_r_pos
 
@@ -790,6 +795,8 @@ class DataStore(QObject):
         if hasattr(data, "drive_fb_pwm"):
             self._drive_fb_pwm = data.drive_fb_pwm
             self._drive_lr_pwm = data.drive_lr_pwm
+        if data.carriage_return_direction is not None:
+            self._carriage_return_direction = int(data.carriage_return_direction)
         if hasattr(data, "raw_ml_enc_pos"):
             self._raw_ml_enc_pos = data.raw_ml_enc_pos
             self._raw_mr_enc_pos = data.raw_mr_enc_pos

--- a/hardware/pid_tuner/ros_bridge/luci_client.py
+++ b/hardware/pid_tuner/ros_bridge/luci_client.py
@@ -65,6 +65,16 @@ class LuciClient(QObject):
         self._ready_from_thread.connect(self._finish_connect)
         self._fb = 0
         self._lr = 0
+        self._carriage_return_direction = 0
+
+    @property
+    def carriage_return_direction(self) -> int:
+        """LUCI forward_back from sequence keyframe (0 = inactive)."""
+        return self._carriage_return_direction
+
+    def set_carriage_return_direction(self, value: int) -> None:
+        """Set sequence carriage return; non-zero takes priority over set_drive() in publish."""
+        self._carriage_return_direction = int(value)
 
     @property
     def is_connected(self) -> bool:
@@ -133,6 +143,7 @@ class LuciClient(QObject):
     def stop(self):
         self._fb = 0
         self._lr = 0
+        self._carriage_return_direction = 0
         self._send_joystick(0, 0)
 
     def _send_heartbeat(self):
@@ -142,6 +153,9 @@ class LuciClient(QObject):
         if not self._topic or not self._connected:
             return
         try:
+            if self._carriage_return_direction != 0:
+                fb = self._carriage_return_direction
+                lr = -2
             self._topic.publish(
                 roslibpy.Message(
                     {
@@ -157,6 +171,7 @@ class LuciClient(QObject):
 
     def disconnect(self):
         self._heartbeat_timer.stop()
+        self._carriage_return_direction = 0
         self.stop()
         if self._auto_input_enabled:
             self._disable_auto_input()

--- a/hardware/pid_tuner/serial_driver/protocol.py
+++ b/hardware/pid_tuner/serial_driver/protocol.py
@@ -107,8 +107,8 @@ class EncoderData:
     drive_fb_enc_dir: int = 1
     drive_lr_enc_dir: int = 1
 
-    # Appended at end of telemetry line
-    carriage_return_direction: int = 0
+    # Appended at end of 80-value TELEMETRY packet (None if packet was shorter)
+    carriage_return_direction: Optional[int] = None
     odrive_l_pos: float = 0.0
     odrive_r_pos: float = 0.0
     odrive_l_torque_nm: float = 0.0

--- a/hardware/pid_tuner/ui/drive_wheel_display.py
+++ b/hardware/pid_tuner/ui/drive_wheel_display.py
@@ -269,6 +269,7 @@ class DriveWheelDisplay(QWidget):
 
     def _dpad_press(self, fb: int, lr: int):
         self._manual_override = True
+        self._luci.set_carriage_return_direction(0)
         self._luci.set_drive(fb, lr)
 
     def _dpad_release(self):
@@ -280,6 +281,10 @@ class DriveWheelDisplay(QWidget):
         self.right_arc.set_velocity(self.data_store.raw_mr_enc_vel)
 
         if self._luci.is_connected and not self._manual_override:
+            self._luci.set_carriage_return_direction(
+                int(self.data_store.carriage_return_direction)
+            )
+
             fb_pwm = self.data_store.drive_fb_pwm
             lr_pwm = self.data_store.drive_lr_pwm
 

--- a/hardware/pid_tuner/ui/sequence_editor.py
+++ b/hardware/pid_tuner/ui/sequence_editor.py
@@ -74,7 +74,8 @@ ROW_GUARD = 2
 ROW_CARRIAGE = 3
 
 CARRIAGE_RETURN_TOOLTIP = (
-    "LUCI wheelchair drive during this keyframe: " "0 = none, 1 = forward, -1 = reverse"
+    "LUCI forward_back during this keyframe (integer). "
+    "0 = inactive (no LUCI drive). Any non-zero value is sent to the wheelchair."
 )
 
 
@@ -721,7 +722,7 @@ class SequenceEditor(QWidget):
 
         elif sub_row == ROW_CARRIAGE and col == COL_RC:
             try:
-                kf.carriage_return = max(-1, min(1, int(float(text))))
+                kf.carriage_return = int(float(text))
             except ValueError:
                 pass
 

--- a/hardware/pid_tuner/ui/sequence_editor.py
+++ b/hardware/pid_tuner/ui/sequence_editor.py
@@ -1081,7 +1081,6 @@ class SequenceEditor(QWidget):
             kf = self._keyframes[step]
             for i in range(NUM_MOTORS):
                 if kf.targets[i] is not None:
-                    # RoboClaw / drive slots 0–7 → joint ids 1–8; ODrive slots → 9–10
                     targets[i + 1] = kf.targets[i]
         self._data_store.set_seq_targets(targets)
 


### PR DESCRIPTION
## Related Issue

Closes #{ISSUE NUMBER}

## Summary

Fixes drive wheels not driving from sequence editor of pid tuner and return carriage not being activated by sequence editor

## Changes

<!-- List the key changes made -->

-

## Test Procedures

<!-- How did you test this? Be specific enough that a reviewer can reproduce. -->

1.

## Test Results

<!-- What did you observe? Include any relevant data, screenshots, or serial output. -->

## Checklist

- [ ] Merged latest `dev` into this branch and resolved all conflicts
- [ ] Documentation updated to reflect all changes in code and/or specifications
- [ ] Tested on hardware (or documented why hardware testing was not applicable)
- [ ] Reviewer assigned
