### PR TITLE
Add partial gripper position control to arm_driver (#235)

### DIFF
--- a/core/rammp_prototype_behavior/rammp_prototype_behavior/mocks/mock_arm.py
+++ b/core/rammp_prototype_behavior/rammp_prototype_behavior/mocks/mock_arm.py
@@ -126,6 +126,11 @@ class KinovaArm:
         self.gripper_position = 1.0
         self._gripper_position_command(1, blocking)
 
+    def set_gripper_position(self, value, blocking=True):
+        value = min(max(float(value), 0.0), 1.0)
+        self.gripper_position = value
+        self._gripper_position_command(value, blocking)
+
     def choose_from_speed_presets(self, speed_preset: SpeedPreset):
         if not isinstance(speed_preset, SpeedPreset) or speed_preset in [
             SpeedPreset.DEFAULT,

--- a/hardware/arm_driver/Arm Control Node.md
+++ b/hardware/arm_driver/Arm Control Node.md
@@ -110,15 +110,16 @@ ______________________________________________________________________
 
 ## Service Servers
 
-| Service                   | Type                                   | Notes                                                       |
-| ------------------------- | -------------------------------------- | ----------------------------------------------------------- |
-| `/arm/set_mode`           | `arm_interfaces/srv/SetMode`           | Rejected when in `ERROR`                                    |
-| `/arm/clear_error`        | `std_srvs/srv/Trigger`                 | Only valid exit from `ERROR`; clears Kortex hardware faults |
-| `/arm/set_speed_preset`   | `arm_interfaces/srv/SetSpeedPreset`    |                                                             |
-| `/arm/get_speed_preset`   | `arm_interfaces/srv/GetSpeedPreset`    |                                                             |
-| `/arm/open_gripper`       | `std_srvs/srv/Trigger`                 |                                                             |
-| `/arm/close_gripper`      | `std_srvs/srv/Trigger`                 |                                                             |
-| `/arm/check_reachability` | `arm_interfaces/srv/CheckReachability` |                                                             |
+| Service                     | Type                                    | Notes                                                                                                            |
+| --------------------------- | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `/arm/set_mode`             | `arm_interfaces/srv/SetMode`            | Rejected when in `ERROR`                                                                                         |
+| `/arm/clear_error`          | `std_srvs/srv/Trigger`                  | Only valid exit from `ERROR`; clears Kortex hardware faults                                                      |
+| `/arm/set_speed_preset`     | `arm_interfaces/srv/SetSpeedPreset`     |                                                                                                                  |
+| `/arm/get_speed_preset`     | `arm_interfaces/srv/GetSpeedPreset`     |                                                                                                                  |
+| `/arm/open_gripper`         | `std_srvs/srv/Trigger`                  |                                                                                                                  |
+| `/arm/close_gripper`        | `std_srvs/srv/Trigger`                  |                                                                                                                  |
+| `/arm/set_gripper_position` | `arm_interfaces/srv/SetGripperPosition` | Partial gripper position; `position` in \[0, 1\] (0.0 = open, 1.0 = closed, clamped). Rejected in `IDLE`/`ERROR` |
+| `/arm/check_reachability`   | `arm_interfaces/srv/CheckReachability`  |                                                                                                                  |
 
 ## Action Servers
 

--- a/hardware/arm_driver/arm_driver/arm_driver.py
+++ b/hardware/arm_driver/arm_driver/arm_driver.py
@@ -13,6 +13,7 @@ from arm_interfaces.action import Calibrate, ExecuteTrajectory, ReachPreset
 from arm_interfaces.srv import (
     CheckReachability,
     GetSpeedPreset,
+    SetGripperPosition,
     SetMode,
     SetSpeedPreset,
 )
@@ -235,6 +236,12 @@ class ArmDriverNode(rclpy.node.Node):
             Trigger,
             "/arm/close_gripper",
             self._on_close_gripper,
+            callback_group=self._service_group,
+        )
+        self._set_gripper_position_srv = self.create_service(
+            SetGripperPosition,
+            "/arm/set_gripper_position",
+            self._on_set_gripper_position,
             callback_group=self._service_group,
         )
         self._check_reachability_srv = self.create_service(
@@ -717,6 +724,51 @@ class ArmDriverNode(rclpy.node.Node):
             self._arm.close_gripper()
             response.success = True
             response.message = "Gripper closed"
+        except Exception as e:
+            response.success = False
+            response.message = str(e)
+        return response
+
+    def _on_set_gripper_position(self, request, response):
+        """Handle a /arm/set_gripper_position service request.
+
+        Commands the gripper to a partial position. ``request.position`` is a
+        normalized target where 0.0 is fully open and 1.0 is fully closed;
+        values outside [0, 1] are clamped. Gated by the same state rules as
+        the open/close services (rejected in IDLE/ERROR).
+
+        Args:
+            request: SetGripperPosition request with ``position`` (float32).
+            response: Response with ``success`` (bool) and ``message`` (str).
+
+        Returns:
+            The populated service response.
+        """
+        if not self._arm:
+            response.success = False
+            response.message = "Arm not connected"
+            return response
+
+        if self._state in (ArmState.IDLE, ArmState.ERROR):
+            response.success = False
+            response.message = (
+                f"Gripper commands not allowed in state {self._state.name}"
+            )
+            return response
+
+        requested = float(request.position)
+        position = min(max(requested, 0.0), 1.0)
+
+        try:
+            self._arm.set_gripper_position(position)
+            response.success = True
+            if position != requested:
+                response.message = (
+                    f"Gripper set to {position:.2f} "
+                    f"(requested {requested:.2f}, clamped to [0, 1])"
+                )
+            else:
+                response.message = f"Gripper set to {position:.2f}"
         except Exception as e:
             response.success = False
             response.message = str(e)

--- a/hardware/arm_driver/arm_driver/arm_interface.py
+++ b/hardware/arm_driver/arm_driver/arm_interface.py
@@ -679,6 +679,10 @@ class KinovaArm:
     def close_gripper(self, blocking=True):
         self._gripper_position_command(1, blocking)
 
+    def set_gripper_position(self, value, blocking=True):
+        value = min(max(float(value), 0.0), 1.0)
+        self._gripper_position_command(value, blocking)
+
     def set_joint_limits(
         self,
         speed_limits=(60, 60, 60, 60, 60, 60, 60),

--- a/hardware/arm_driver/test/test_gripper_position.py
+++ b/hardware/arm_driver/test/test_gripper_position.py
@@ -1,0 +1,124 @@
+"""Unit tests for the /arm/set_gripper_position service (issue #235).
+
+Adds continuous partial-position gripper control. These tests mock KinovaArm
+entirely — no hardware required.
+
+Run with:
+    cd /path/to/Demo-Software
+    python -m pytest hardware/arm_driver/test/test_gripper_position.py -v
+"""
+
+import pytest
+import rclpy
+from arm_interfaces.srv import SetGripperPosition
+from unittest.mock import MagicMock, patch
+
+
+@pytest.fixture(scope="module", autouse=True)
+def ros_context():
+    rclpy.init()
+    yield
+    rclpy.shutdown()
+
+
+def _make_node():
+    """Create ArmDriverNode with KinovaArm, xacro and CollisionChecker mocked.
+
+    Returns (node, mock_arm, ArmState).
+    """
+    with (
+        patch("arm_driver.arm_driver.KinovaArm") as MockArm,
+        patch("arm_driver.arm_driver.subprocess.run") as mock_run,
+        patch("arm_driver.arm_driver.CollisionChecker") as MockChecker,
+    ):
+        mock_arm = MagicMock()
+        mock_arm.actuator_count = 7
+        mock_arm.get_fault_state.return_value = ("ARMSTATE_SERVOING_READY", False)
+        MockArm.return_value = mock_arm
+
+        mock_run.return_value = MagicMock(stdout="<robot/>")
+
+        mock_checker = MagicMock()
+        mock_checker.check.return_value = False
+        MockChecker.return_value = mock_checker
+
+        from arm_driver.arm_driver import ArmDriverNode, ArmState
+
+        node = ArmDriverNode()
+        # Set self._arm to the mock while the patches are still active.
+        node._try_connect_arm()
+        return node, mock_arm, ArmState
+
+
+def _call(node, position):
+    req = SetGripperPosition.Request()
+    req.position = float(position)
+    resp = SetGripperPosition.Response()
+    return node._on_set_gripper_position(req, resp)
+
+
+class TestSetGripperPosition:
+    def test_partial_position_forwarded_to_arm(self):
+        """A valid in-range position is passed straight through to the arm."""
+        node, mock_arm, ArmState = _make_node()
+        try:
+            node._state = ArmState.DRINKING  # gripper-allowed (non IDLE/ERROR) state
+            resp = _call(node, 0.5)
+            assert resp.success
+            mock_arm.set_gripper_position.assert_called_once_with(0.5)
+        finally:
+            node.destroy_node()
+
+    def test_value_above_one_is_clamped(self):
+        node, mock_arm, ArmState = _make_node()
+        try:
+            node._state = ArmState.MANUAL
+            resp = _call(node, 1.5)
+            assert resp.success
+            mock_arm.set_gripper_position.assert_called_once_with(1.0)
+            assert "clamp" in resp.message.lower()
+        finally:
+            node.destroy_node()
+
+    def test_value_below_zero_is_clamped(self):
+        node, mock_arm, ArmState = _make_node()
+        try:
+            node._state = ArmState.MANUAL
+            resp = _call(node, -0.2)
+            assert resp.success
+            mock_arm.set_gripper_position.assert_called_once_with(0.0)
+            assert "clamp" in resp.message.lower()
+        finally:
+            node.destroy_node()
+
+    def test_rejected_in_idle(self):
+        """Mirrors open/close gating: gripper commands are refused in IDLE."""
+        node, mock_arm, ArmState = _make_node()
+        try:
+            assert node._state == ArmState.IDLE
+            resp = _call(node, 0.5)
+            assert not resp.success
+            mock_arm.set_gripper_position.assert_not_called()
+        finally:
+            node.destroy_node()
+
+    def test_rejected_in_error(self):
+        node, mock_arm, ArmState = _make_node()
+        try:
+            node._state = ArmState.ERROR
+            resp = _call(node, 0.5)
+            assert not resp.success
+            mock_arm.set_gripper_position.assert_not_called()
+        finally:
+            node.destroy_node()
+
+    def test_rejected_when_arm_not_connected(self):
+        node, mock_arm, ArmState = _make_node()
+        try:
+            node._state = ArmState.DRINKING
+            node._arm = None
+            resp = _call(node, 0.5)
+            assert not resp.success
+            assert "not connected" in resp.message.lower()
+        finally:
+            node.destroy_node()

--- a/interfaces/arm_interfaces/CMakeLists.txt
+++ b/interfaces/arm_interfaces/CMakeLists.txt
@@ -29,6 +29,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/SetSpeedPreset.srv"
   "srv/GetSpeedPreset.srv"
   "srv/CheckReachability.srv"
+  "srv/SetGripperPosition.srv"
   "action/ReachPreset.action"
   "action/ExecuteTrajectory.action"
   "action/Calibrate.action"

--- a/interfaces/arm_interfaces/srv/SetGripperPosition.srv
+++ b/interfaces/arm_interfaces/srv/SetGripperPosition.srv
@@ -1,0 +1,12 @@
+# Service definition for commanding the gripper to a partial position.
+# Adds continuous position control alongside the existing /arm/open_gripper and
+# /arm/close_gripper services (which remain unchanged).
+
+# Request message
+# Normalized target position: 0.0 = fully open, 1.0 = fully closed.
+# Values outside [0.0, 1.0] are clamped.
+float32 position
+---
+# Response message
+bool success
+string message


### PR DESCRIPTION
Adds an additive /arm/set_gripper_position service for continuous partial gripper positioning (0.0 open .. 1.0 closed), leaving the existing open/close API unchanged.

- arm_interfaces: new SetGripperPosition.srv (float32 position)
- arm_driver: /arm/set_gripper_position service + handler (state-gated like open/close, clamps to [0, 1]); KinovaArm.set_gripper_position() wrapper
- mock_arm: mirror set_gripper_position
- tests: hardware-free unit tests for the new service
- docs: Arm Control Node.md service table

## Related Issue

Closes #235 

## Summary

Added ability to partially open and close the gripper via a new `/arm/set_gripper_position` service

## Changes

- **`arm_interfaces`**: New `SetGripperPosition.srv` (`float32 position`; 0.0 = fully open, 1.0 = fully closed), registered in `CMakeLists.txt`
- **`arm_driver`**: New `/arm/set_gripper_position` service server + `_on_set_gripper_position` handler. State-gated identically to open/close (rejected in `IDLE`/`ERROR`, rejected when arm not connected). Out-of-range values are clamped to [0, 1] with the clamp noted in the response message
- **`arm_interface.py`**: `KinovaArm.set_gripper_position()` wrapper around the existing `_gripper_position_command`
- **`mock_arm.py`**: Mirrored `set_gripper_position` in the behavior-package mock
- **Tests**: New `hardware/arm_driver/test/test_gripper_position.py`
- **Docs**: `Arm Control Node.md` service table updated with the new service

-

## Test Procedures

1. Rebuild interfaces + driver:
   `colcon build --packages-select arm_interfaces arm_driver && source install/setup.bash`
2. Run unit tests:
   `python -m pytest src/Demo-Software/hardware/arm_driver/test/test_gripper_position.py -v`
   Covers: valid position pass-through, clamping >1.0 and <0.0, rejection in `IDLE`, rejection in `ERROR`, rejection when arm not connected.
3. Hardware test on the Kinova Gen3:
   - Launch `arm_driver`, then exit IDLE: `ros2 service call /arm/set_mode arm_interfaces/srv/SetMode "{mode: 5}"`
   - Command a partial close: `ros2 service call /arm/set_gripper_position arm_interfaces/srv/SetGripperPosition "{position: 0.5}"`
   - Sweep 0.0 → 0.25 → 0.5 → 0.75 → 1.0 and visually confirm proportional travel
   - Clamp check: send `{position: 1.5}` and `{position: -0.2}`, confirm success with clamp message
   - Extra: Confirm `/arm/open_gripper` and `/arm/close_gripper` still behave as before

## Test Results

- Untested

## Checklist

- [ x ] Merged latest `dev` into this branch and resolved all conflicts
- [ x ] Documentation updated to reflect all changes in code and/or specifications
- [ ] Tested on hardware (or documented why hardware testing was not applicable)
- [ x ] Reviewer assigned
