### PR TITLE
fixed pin number for limit switch

### DIFF
--- a/hardware/rammp_prototype_driver/firmware/Base/src/Constants/Constants.h
+++ b/hardware/rammp_prototype_driver/firmware/Base/src/Constants/Constants.h
@@ -14,7 +14,7 @@ extern RoboClaw roboclaw_carriages;
 #define RC_LOADCELL_PIN A16
 
 #define CARRIAGE_SW1_PIN 23 // ML carriage forward limit switch
-#define CARRIAGE_SW2_PIN 22 // ML carriage backward limit switch
+#define CARRIAGE_SW2_PIN 4  // ML carriage backward limit switch
 #define CARRIAGE_SW3_PIN 13 // MR carriage forward limit switch
 #define CARRIAGE_SW4_PIN 33 // MR carriage backward limit switch
 


### PR DESCRIPTION
## Related Issue

Closes #243

## Summary

<!-- Brief description of what this PR adds or fixes -->
Fixes pin number for ML limit switch so it works for new PCB

## Changes

<!-- List the key changes made -->

- Change ML bwd pin number

## Test Procedures

<!-- How did you test this? Be specific enough that a reviewer can reproduce. -->

1. Tested limit switch readings on robot

## Test Results

<!-- What did you observe? Include any relevant data, screenshots, or serial output. -->

Confirmed that limit switch stops carriage

## Checklist

- [x] Merged latest `dev` into this branch and resolved all conflicts
- [x] Documentation updated to reflect all changes in code and/or specifications
- [x] Tested on hardware (or documented why hardware testing was not applicable)
- [x] Reviewer assigned
